### PR TITLE
fix: place endpoint partial model matcher before type partial matcher

### DIFF
--- a/api-documentation.js
+++ b/api-documentation.js
@@ -430,12 +430,12 @@ class ApiDocumentation extends AmfHelperMixin(LitElement) {
       this._processSecurityParial(amf);
       return;
     }
-    if (this._isTypePartialModel(amf)) {
-      this._processTypeParial(amf);
-      return;
-    }
     if (this._isEndpointPartialModel(amf)) {
       this._processEndpointParial(amf);
+      return;
+    }
+    if (this._isTypePartialModel(amf)) {
+      this._processTypeParial(amf);
       return;
     }
   }


### PR DESCRIPTION
Type partial model matcher will return true for all nodes, as all nodes contain the DomainElement type. Thus, it will never render the endpoint partial model correctly