### PR TITLE
fix: do not depend on narrow mode to render server selector

### DIFF
--- a/api-documentation.js
+++ b/api-documentation.js
@@ -99,10 +99,11 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
   }
 
   _renderServerSelector() {
-    const { amf, selectedServerType, selectedServerValue, noCustomServer } = this;
+    const { amf, selectedServerType, selectedServerValue, noCustomServer, noServerSelector } = this;
 
-    return this.rendersSelector
-      ? html`<api-server-selector
+    return noServerSelector
+      ? ""
+      : html`<api-server-selector
         class="server-selector"
         slot="content"
         .amf="${amf}"
@@ -112,8 +113,7 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
         ?noCustom="${noCustomServer}"
         @servers-count-changed="${this._handleServersCountChange}">
           <slot name="custom-base-uri" slot="custom-base-uri"></slot>
-        </api-server-selector>`
-      : "" 
+        </api-server-selector>`;
   }
 
   _renderView() {
@@ -412,12 +412,6 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
     this._serversCount = value;
     this._updateServers();
     this.requestUpdate('serversCount', old);
-  }
-
-  get rendersSelector() {
-    const { noServerSelector, narrow } = this;
-
-    return !noServerSelector && !!narrow;
   }
 
   get showsSelector() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-documentation",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-documentation",
   "description": "A main documentation view for AMF model",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "Apache-2.0",
   "main": "api-documentation.js",
   "module": "api-documentation.js",

--- a/test/api-documentation.test.js
+++ b/test/api-documentation.test.js
@@ -800,6 +800,8 @@ describe('<api-documentation>', function() {
           beforeEach(async () => {
             element = await partialFixture(amf);
             element.noServerSelector = true;
+
+            await nextFrame();
           });
 
           it('should not render api-server-selector', () => {


### PR DESCRIPTION
As discused with @jarrodek, narrow mode should not affect server selector render. It should be controlled by `noServerSelector` property.

- Do not use getter, use `noServerSelector`
- Delete describe('in narrow mode') and describe('when not in narrow mode') (every other change is indentation)