### PR TITLE
fix: dispatch server changed event

### DIFF
--- a/api-documentation.d.ts
+++ b/api-documentation.d.ts
@@ -169,9 +169,9 @@ declare namespace ApiElements {
     noServerSelector: boolean|null|undefined;
 
     /**
-     * Do not allow entering custom uris in server selector
+     * Allow entering custom uris in server selector
      */
-    noCustomServer: boolean|null|undefined;
+    allowCustomBaseUri: boolean|null|undefined;
 
     /**
      * Currently rendered view type

--- a/api-documentation.js
+++ b/api-documentation.js
@@ -107,8 +107,8 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
         class="server-selector"
         slot="content"
         .amf="${amf}"
-        .selectedValue="${selectedServerValue}"
         .selectedType="${selectedServerType}"
+        .selectedValue="${selectedServerValue}"
         ?hidden=${!this.showsSelector}
         ?noCustom="${noCustomServer}"
         @servers-count-changed="${this._handleServersCountChange}">
@@ -128,9 +128,9 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
   }
 
   _summaryTemplate() {
-    const { _docsModel } = this;
+    const { _docsModel, baseUri } = this;
 
-    return html`<api-summary .amf="${_docsModel}" .baseUri="${this.effectiveBaseUri}"></api-summary>`;
+    return html`<api-summary .amf="${_docsModel}" .baseUri="${baseUri}"></api-summary>`;
   }
 
   _securityTemplate() {
@@ -414,6 +414,34 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
     this.requestUpdate('serversCount', old);
   }
 
+  get selectedServerValue() {
+    return this._selectedServerValue;
+  }
+
+  set selectedServerValue(value) {
+    const old = this._selectedServerValue;
+    if (old === value) {
+      return;
+    }
+    this._selectedServerValue = value;
+    this._notifyServerChanged();
+    this.requestUpdate('selectedServerValue', old);
+  }
+
+  get selectedServerType() {
+    return this._selectedServerType;
+  }
+
+  set selectedServerType(value) {
+    const old = this._selectedServerType;
+    if (old === value) {
+      return;
+    }
+    this._selectedServerType = value;
+    this._notifyServerChanged();
+    this.requestUpdate('selectedServerType', old);
+  }
+
   get showsSelector() {
     const { selectedType, serversCount } = this;
 
@@ -545,6 +573,18 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
     window.removeEventListener('api-navigation-selection-changed', this._navigationHandler);
   }
 
+  _notifyServerChanged() {
+    this.dispatchEvent(
+      new CustomEvent('api-server-changed', {
+        detail: {
+          selectedValue: this.selectedServerValue,
+          selectedType: this.selectedServerType
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
   /**
    * Registers / unregisters event listeners depending on `state`
    *
@@ -593,8 +633,8 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
 
   _updateServerValues() {
     if (this.servers && !this.selectedServerValue && this.selectedServerType !== "custom") {
-      this.selectedServerValue = this._getServerUri(this.servers[0]);
       this.selectedServerType = "server"
+      this.selectedServerValue = this._getServerUri(this.servers[0]);
 
       return;
     }
@@ -602,8 +642,8 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
     const serverExists = !!(this.servers || []).find(server => this._getServerUri(server) === this.selectedServerValue);
 
     if (!serverExists && this.selectedServerType === "server"){
-      this.selectedServerValue = undefined;
       this.selectedServerType = undefined;
+      this.selectedServerValue = undefined;
     }
   }
 

--- a/api-documentation.js
+++ b/api-documentation.js
@@ -99,7 +99,7 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
   }
 
   _renderServerSelector() {
-    const { amf, selectedServerType, selectedServerValue, noCustomServer, noServerSelector } = this;
+    const { amf, selectedServerType, selectedServerValue, allowCustomBaseUri, noServerSelector } = this;
 
     return noServerSelector
       ? ""
@@ -110,7 +110,7 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
         .selectedType="${selectedServerType}"
         .selectedValue="${selectedServerValue}"
         ?hidden=${!this.showsSelector}
-        ?noCustom="${noCustomServer}"
+        ?allowCustom="${allowCustomBaseUri}"
         @servers-count-changed="${this._handleServersCountChange}">
           <slot name="custom-base-uri" slot="custom-base-uri"></slot>
         </api-server-selector>`;
@@ -345,9 +345,9 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
        */
       noServerSelector: { type: Boolean },
       /**
-       * If true, the server selector custom option is not rendered
+       * If true, the server selector custom base URI option is rendered
        */
-      noCustomServer: { type: Boolean },
+      allowCustomBaseUri: { type: Boolean },
       /**
        * The URI of the server currently selected in the server selector
        */

--- a/api-documentation.js
+++ b/api-documentation.js
@@ -580,8 +580,7 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
           selectedValue: this.selectedServerValue,
           selectedType: this.selectedServerType
         },
-        bubbles: true,
-        composed: true,
+        composed: true
       })
     );
   }

--- a/demo/ie.js
+++ b/demo/ie.js
@@ -25,7 +25,7 @@ class ComponentDemo extends ApiDemoPageBase {
       'narrow',
       'noTryit',
       'noServerSelector',
-      'noCustomServer',
+      'allowCustomBaseUri',
       'inlineMethods',
       'scrollTarget',
       'selected',
@@ -35,7 +35,7 @@ class ComponentDemo extends ApiDemoPageBase {
     this.codeSnippets = true;
     this.renderSecurity = true;
     this.noServerSelector = false;
-    this.noCustomServer = false;
+    this.allowCustomBaseUri = false;
     this.redirectUri = 'https://auth.advancedrestclient.com/oauth-popup.html';
     this.scrollTarget = window;
 
@@ -135,7 +135,7 @@ class ComponentDemo extends ApiDemoPageBase {
       inlineMethods,
       noTryit,
       noServerSelector,
-      noCustomServer
+      allowCustomBaseUri
     } = this;
     return html `
     <section class="documentation-section">
@@ -156,7 +156,7 @@ class ComponentDemo extends ApiDemoPageBase {
             .inlineMethods="${inlineMethods}"
             .noTryIt="${noTryit}"
             .noServerSelector="${noServerSelector}"
-            .noCustomServer="${noCustomServer}"
+            .allowCustomBaseUri="${allowCustomBaseUri}"
             ?narrow="${narrow}"
             ?legacy="${legacy}"
             handleNavigationEvents

--- a/demo/index.js
+++ b/demo/index.js
@@ -27,7 +27,7 @@ class ComponentDemo extends ApiDemoPageBase {
       'narrow',
       'noTryit',
       'noServerSelector',
-      'noCustomServer',
+      'allowCustomBaseUri',
       'inlineMethods',
       'scrollTarget',
       'selected',
@@ -35,7 +35,7 @@ class ComponentDemo extends ApiDemoPageBase {
     ]);
     this.noTryit = false;
     this.noServerSelector = false;
-    this.noCustomServer = false;
+    this.allowCustomBaseUri = false;
     this.codeSnippets = true;
     this.renderSecurity = true;
 
@@ -140,7 +140,7 @@ class ComponentDemo extends ApiDemoPageBase {
       inlineMethods,
       noTryit,
       noServerSelector,
-      noCustomServer
+      allowCustomBaseUri
     } = this;
     return html `
     <section class="documentation-section">
@@ -167,7 +167,7 @@ class ComponentDemo extends ApiDemoPageBase {
             .inlineMethods="${inlineMethods}"
             .noTryIt="${noTryit}"
             .noServerSelector="${noServerSelector}"
-            .noCustomServer="${noCustomServer}"
+            .allowCustomBaseUri="${allowCustomBaseUri}"
             ?narrow="${narrow}"
             ?legacy="${legacy}"
             handleNavigationEvents
@@ -213,9 +213,9 @@ class ComponentDemo extends ApiDemoPageBase {
         <anypoint-checkbox
           aria-describedby="mainOptionsLabel"
           slot="options"
-          name="noCustomServer"
+          name="allowCustomBaseUri"
           @change="${this._toggleMainOption}"
-          >No custom server</anypoint-checkbox
+          >Allow custom base URI</anypoint-checkbox
         >
       </arc-interactive-demo>
     </section>`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -987,9 +987,9 @@
       }
     },
     "@api-components/api-request-panel": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request-panel/-/api-request-panel-4.1.1.tgz",
-      "integrity": "sha512-yTbyPfxjRFktbXGyS+lMMBjh/y90PeS7YTa5BJ4r1UO/KalXnYNEktm4QriePvuX9pAslBcV6Nwi2lZl35oLHw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request-panel/-/api-request-panel-4.1.3.tgz",
+      "integrity": "sha512-rOMBxqbnwXPeHHNlgV1RqrewSRtEcA7WD7DbOlsM13omHDZmwX6yivd1mtj4miYdiwgRBdEQBIMtsHEj4ERWyQ==",
       "requires": {
         "@advanced-rest-client/arc-scroll-target-mixin": "^1.0.2",
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
@@ -997,7 +997,7 @@
         "@advanced-rest-client/response-view": "^3.0.4",
         "@api-components/amf-helper-mixin": "^4.0.24",
         "@api-components/api-request-editor": "^4.0.5",
-        "@api-components/api-server-selector": "^0.2.4",
+        "@api-components/api-server-selector": "^0.3.2",
         "@api-components/raml-aware": "^3.0.0",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1"
@@ -1066,9 +1066,9 @@
       }
     },
     "@api-components/api-server-selector": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.2.4.tgz",
-      "integrity": "sha512-wq3far3lRrnl99SMDuKlNzplMcqolhYo+46ljH2gfTaIpW4cbpRx8uwHY52MlvXhW1lawHHZkGTwRPIILkgBVA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.3.2.tgz",
+      "integrity": "sha512-wFfzL2IgxUeOJcN2pDpbK9qa5ZG++j9MUQZaiUC+NpxpBhHI6qt/CUROlVumf+yE3VTjY59Nokx9UHpx6XQO4Q==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.5",
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
@@ -1176,12 +1176,12 @@
       }
     },
     "@api-components/api-view-model-transformer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-view-model-transformer/-/api-view-model-transformer-4.0.2.tgz",
-      "integrity": "sha512-KFwK1igylbacCmqREJ/p0sp9yFH/sXfHx+OZaiUUj49BLCA37XJfBlURhVrFEbuEFQ+HrcdaD0ESoVjhxtw5aA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@api-components/api-view-model-transformer/-/api-view-model-transformer-4.0.3.tgz",
+      "integrity": "sha512-Srw3Q0FH1oq8BCMea4xkZxRjStfBpfG3T57mZcSDmJCxUieS5WftZW9ExGEGjP2RmdkIf68IOpIHJR3i5wIXsQ==",
       "requires": {
         "@advanced-rest-client/events-target-mixin": "^3.0.0",
-        "@api-components/amf-helper-mixin": "^4.0.14",
+        "@api-components/amf-helper-mixin": "^4.0.26",
         "@api-components/api-example-generator": "^4.0.3",
         "lit-element": "^2.2.1"
       }
@@ -2752,9 +2752,9 @@
       }
     },
     "@open-wc/building-utils": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.3.tgz",
-      "integrity": "sha512-lO/HD2wEl2avRSgqISeP4S1zPQEGRQ/+Zh8RBk9AggDma3uPiRU0RbuRvhunmu7hFWVDBj5o1FRJ7xJ94AWCnw==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.4.tgz",
+      "integrity": "sha512-ByknIanbo2wSpNs7gHy/hBHmPOO91IOJCDravSNreK88XdTd4vnCkx0DrRltgwvPIg7GVHWv/NFfSfWecRrh4Q==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -2804,16 +2804,16 @@
       }
     },
     "@open-wc/karma-esm": {
-      "version": "2.13.23",
-      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.23.tgz",
-      "integrity": "sha512-UnC0Vy06F5doojitKIkG+UMbvJBqfRf6o5bdcXaOAd+7SpvpGRwmOq9+/4mkqzIKe/EIiTKc2SoCIh82JI0CTw==",
+      "version": "2.13.26",
+      "resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.26.tgz",
+      "integrity": "sha512-LAxCYdJpSvDjXtixbsoYxhBzR22TbwqIm4nR9wbisJcIiOLK2lJQe2BtbATcBWDbFAroWLRtmubFtF53DiOKPA==",
       "dev": true,
       "requires": {
-        "@open-wc/building-utils": "^2.16.3",
+        "@open-wc/building-utils": "^2.16.4",
         "babel-plugin-istanbul": "^5.1.4",
         "chokidar": "^3.0.0",
         "deepmerge": "^4.2.2",
-        "es-dev-server": "^1.46.2",
+        "es-dev-server": "^1.46.5",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
         "portfinder": "^1.0.21",
@@ -2821,20 +2821,20 @@
       }
     },
     "@open-wc/semantic-dom-diff": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.7.tgz",
-      "integrity": "sha512-7SyZLBoXxYMIq2mQh3kJ80a09+M+ZpOiobBpwbW/8TKZEoOriB+eWAej5yPj6bM/XvUfn4y725vyS58U+GBeSw==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.8.tgz",
+      "integrity": "sha512-wYk9REynp75vgfH3gh1p0718K0wjiV04g+wjGtc+nzx+ChXRO9U2W7JTCniRBG8fAW2rBhzkS0GVQs8kLhjK6w==",
       "dev": true
     },
     "@open-wc/testing": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.11.tgz",
-      "integrity": "sha512-QtLA5jGpfEJOoC0ka2OAqRAAZ0/pbgWPVLzgKPu//OC3CDxvVgKdEObW9pXVKpti5oLa7NRMxeJcTMkE4aO68Q==",
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.13.tgz",
+      "integrity": "sha512-LdAt3yZFM4nLjuGp0l189/2CJ8x1BHA0qt6cw9cq3WojwWSS4iFX8wWGl31+Lkzg3a+y5D6QbMRWpZOaTyTL9g==",
       "dev": true,
       "requires": {
         "@open-wc/chai-dom-equals": "^0.12.36",
-        "@open-wc/semantic-dom-diff": "^0.17.7",
-        "@open-wc/testing-helpers": "^1.7.1",
+        "@open-wc/semantic-dom-diff": "^0.17.8",
+        "@open-wc/testing-helpers": "^1.7.2",
         "@types/chai": "^4.1.7",
         "@types/chai-dom": "^0.0.9",
         "@types/mocha": "^5.0.0",
@@ -2847,18 +2847,18 @@
       }
     },
     "@open-wc/testing-helpers": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.7.1.tgz",
-      "integrity": "sha512-v7AYqIGA50mFfwuZNqCxB0ZWI+aioZtiprBMl5bZT4eRMRz876jRMiX9y327RwwisGie6+HDIJHwhWjrd1GdOA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.7.2.tgz",
+      "integrity": "sha512-ilUdoObOTu9IO8cbv7MiLGEpmoIl6+31OFblOfq7UseqL8+KId88spqhUFc3UToX429HHypsUVuKHFfEST3oXw==",
       "dev": true
     },
     "@open-wc/testing-karma": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.12.tgz",
-      "integrity": "sha512-Hl0VGwBUQKuyuDrtr2dLi1SdD/BbkImuuE/Ieui37RyRevZy+QH97dIHvHLOSyrCqzaEzV9ePvxiPc7lEHnYIQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.15.tgz",
+      "integrity": "sha512-PjaMeppysH5yAjNnPvW1rC+kFPj3WEyNw1S0uRf/HBYYz4m7wjjai8CDiHBzXxJnhl8i/OZwMuP/m71yEd3vSw==",
       "dev": true,
       "requires": {
-        "@open-wc/karma-esm": "^2.13.23",
+        "@open-wc/karma-esm": "^2.13.26",
         "axe-core": "^3.3.1",
         "karma": "^4.1.0",
         "karma-chrome-launcher": "^3.1.0",
@@ -3671,9 +3671,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.1.tgz",
+      "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3834,9 +3834,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -4154,9 +4154,9 @@
       }
     },
     "babel-plugin-dynamic-import-node": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
@@ -4495,13 +4495,13 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+      "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001038",
-        "electron-to-chromium": "^1.3.390",
+        "caniuse-lite": "^1.0.30001043",
+        "electron-to-chromium": "^1.3.413",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
       }
@@ -4684,9 +4684,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001042",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
-      "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw==",
+      "version": "1.0.30001045",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
+      "integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A==",
       "dev": true
     },
     "caseless": {
@@ -4984,9 +4984,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.52.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.2.tgz",
-      "integrity": "sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ=="
+      "version": "5.53.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.53.2.tgz",
+      "integrity": "sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -6156,9 +6156,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.412",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz",
-      "integrity": "sha512-4bVdSeJScR8fT7ERveLWbxemY5uXEHVseqMRyORosiKcTUSGtVwBkV8uLjXCqoFLeImA57Z9hbz3TOid01U4Hw==",
+      "version": "1.3.414",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.414.tgz",
+      "integrity": "sha512-UfxhIvED++qLwWrAq9uYVcqF8FdeV9sU2S7qhiHYFODxzXRrd1GZRl/PjITHsTEejgibcWDraD8TQqoHb1aCBQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -6315,9 +6315,9 @@
       }
     },
     "es-dev-server": {
-      "version": "1.46.2",
-      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.46.2.tgz",
-      "integrity": "sha512-pqJ1bejSEbcxXFcMi4egkLaLWg5ASaxNeSRiGS9vpxu3S5f0aWX8XgYwifT6VeBpEHalkwb10prm/nvDCZKQlw==",
+      "version": "1.46.5",
+      "resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.46.5.tgz",
+      "integrity": "sha512-LYLRyDbNGvKqBZEuTfTAT8aAEhb0ns0+NBGD+aje+VyxvUTiEUvpFGIzonzZhwiZFCxmDsdR+8q92j7gZzBZAQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -6331,7 +6331,7 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-transform-template-literals": "^7.8.3",
         "@babel/preset-env": "^7.9.0",
-        "@open-wc/building-utils": "^2.16.3",
+        "@open-wc/building-utils": "^2.16.4",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/pluginutils": "^3.0.0",
         "@types/minimatch": "^3.0.3",
@@ -6359,7 +6359,7 @@
         "opn": "^5.4.0",
         "parse5": "^5.1.1",
         "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.5.4",
+        "polyfills-loader": "^1.5.6",
         "portfinder": "^1.0.21",
         "strip-ansi": "^5.2.0",
         "systemjs": "^4.0.0",
@@ -6560,9 +6560,9 @@
       "dev": true
     },
     "eslint-config-prettier": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
-      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -8716,9 +8716,9 @@
       "integrity": "sha512-6UKHqnNs5lYROn03wf1BTw7DQx5tW616DTigjbo0JHV97D3HzIqYmPVCBSNsfEfQOrfpFqmPZJvaC3cMNOT0Yw=="
     },
     "jszip": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.3.0.tgz",
-      "integrity": "sha512-EJ9k766htB1ZWnsV5ZMDkKLgA+201r/ouFF8R2OigVjVdcm2rurcBrrdXaeqBJbqnUVMko512PYmlncBKE1Huw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -10815,13 +10815,13 @@
       }
     },
     "polyfills-loader": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.4.tgz",
-      "integrity": "sha512-Jttph/AKpsmtw5+HGeCqZYaKTYZ3WswVgnTuSzUZOpChSETXiYQ1eihMiTfPIoD9FpIsTb7Ow0VHTFChBvzw9g==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.6.tgz",
+      "integrity": "sha512-01tVO5O0iEX1Pzhamoy24trXmjS75WsqqtcRvMVeg3FnXcB9BPTtkNtiiPh3LWYDQBS+mlngCDxglXK1629jsQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
-        "@open-wc/building-utils": "^2.16.3",
+        "@open-wc/building-utils": "^2.16.4",
         "@webcomponents/webcomponentsjs": "^2.4.0",
         "abortcontroller-polyfill": "^1.4.0",
         "core-js-bundle": "^3.6.0",
@@ -11395,9 +11395,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
-      "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
+      "integrity": "sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -11542,13 +11542,13 @@
       }
     },
     "rollup-plugin-index-html": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-index-html/-/rollup-plugin-index-html-1.11.0.tgz",
-      "integrity": "sha512-/XOjrefVf5undG/zAa+mVRJDSTFSgjFAuHmDNCOg5H4TYffBNYg55cS2mhEed/8yv91xZ1FWdL4Z7hbSe1fwdA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-index-html/-/rollup-plugin-index-html-1.11.1.tgz",
+      "integrity": "sha512-hvXF7KkKtcwrfpEnzAVahc32+LD6gDwJWHIjxxIO3aADRypQf4enOwTK0saW8BCyzIRX0t3rQoAQLwu+cP7gug==",
       "dev": true,
       "requires": {
         "@import-maps/resolve": "^0.2.6",
-        "@open-wc/building-utils": "^2.16.3",
+        "@open-wc/building-utils": "^2.16.4",
         "deepmerge": "^4.2.2",
         "lit-html": "^1.0.0",
         "md5": "^2.2.1",
@@ -12160,9 +12160,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
+      "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -12194,9 +12194,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-documentation",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-documentation",
   "description": "A main documentation view for AMF model",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "api-documentation.js",
   "module": "api-documentation.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@api-components/api-endpoint-documentation": "^4.0.4",
     "@api-components/api-method-documentation": "^4.0.7",
     "@api-components/api-security-documentation": "^4.0.5",
-    "@api-components/api-server-selector": "^0.2.1",
+    "@api-components/api-server-selector": "^0.3.2",
     "@api-components/api-summary": "^4.0.2",
     "@api-components/api-type-documentation": "^4.0.3",
     "@api-components/raml-aware": "^3.0.0",

--- a/test/api-documentation.test.js
+++ b/test/api-documentation.test.js
@@ -617,7 +617,7 @@ describe('<api-documentation>', function() {
         });
 
         it('should set serversCount', () => {
-          assert.equal(element.serversCount, 4);
+          assert.equal(element.serversCount, 3);
         });
 
         it('should update selectedServerValue and selectedServerType using the first available server', () => {
@@ -665,7 +665,7 @@ describe('<api-documentation>', function() {
           });
 
           it('should set serversCount', () => {
-            assert.equal(element.serversCount, 1);
+            assert.equal(element.serversCount, 0);
           });
 
           it('should hide api-server-selector', () => {

--- a/test/api-documentation.test.js
+++ b/test/api-documentation.test.js
@@ -673,6 +673,32 @@ describe('<api-documentation>', function() {
           });
         });
 
+        describe('allowCustomBaseUri is true', () => {
+          let serverSelector;
+
+          beforeEach(async () => {
+            element = await fixture(html`
+              <api-documentation 
+                .amf="${amf}" 
+                .selectedType="${selectedType}"
+                narrow allowCustomBaseUri></api-documentation>
+            `);
+
+            serverSelector = element.shadowRoot.querySelector('api-server-selector');
+            serverSelector.servers = [];
+
+            await nextFrame();
+          });
+
+          it('should set serversCount to one', () => {
+            assert.equal(element.serversCount, 1);
+          });
+
+          it('should hide api-server-selector', () => {
+            assert.isTrue(serverSelector.hidden);
+          });
+        });
+
         describe('selecting a slot server', () => {
           let handler;
           let dispatchedEvent;

--- a/test/api-documentation.test.js
+++ b/test/api-documentation.test.js
@@ -594,7 +594,6 @@ describe('<api-documentation>', function() {
         let amf;
         let selectedType;
 
-        
         beforeEach(async () => {
           amf = await AmfLoader.load(null, compact);
           selectedType = 'method';
@@ -675,19 +674,38 @@ describe('<api-documentation>', function() {
         });
 
         describe('selecting a slot server', () => {
-          beforeEach(() => {
+          let handler;
+          let dispatchedEvent;
+
+          beforeEach(async () => {
             const event = {
               detail: {
                 selectedValue: 'http://customServer.com',
                 selectedType: 'slot'
               }
             };
+
+            handler = (e) => (dispatchedEvent = e);
+            element.addEventListener('api-server-changed', handler);
             window.dispatchEvent(new CustomEvent('api-server-changed', event));
+
+            await nextFrame();
+          });
+
+          afterEach(() => {
+            element.removeEventListener('api-server-changed', handler);
           });
 
           it('should update selectedServerValue and selectedServerType', () => {
             assert.equal(element.selectedServerValue, 'http://customServer.com');
             assert.equal(element.selectedServerType, 'slot');
+          });
+
+          it('should dispatch the "api-server-changed event"', () => {
+            assert.deepEqual(dispatchedEvent.detail, {
+              selectedValue: 'http://customServer.com',
+              selectedType: 'slot'
+            });
           });
         });
 
@@ -795,7 +813,7 @@ describe('<api-documentation>', function() {
             assert.isTrue(_updateServerValuesSpy.called);
           });
         });
-      
+
         describe('noServerSelector is true', () => {
           beforeEach(async () => {
             element = await partialFixture(amf);


### PR DESCRIPTION
- We dispatch an api-server-changed event so api console can set selectedServerValue/selectedServerType to api-request-panel
- Fixes bug where initial server value wasn't set due to setting selectedValue before selectedType (!!!) (this bug has to be fixed in api-request-panel too)
- Passes baseUri to summary instead of `selectedServerValue`
