### PR TITLE
fix: apic-406 reset when selected method id not longer exists

### DIFF
--- a/api-documentation.js
+++ b/api-documentation.js
@@ -609,8 +609,9 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
       return;
     }
     let result;
+    const summary = 'summary'
     switch (selectedType) {
-      case 'summary': result = model; break;
+      case summary: result = model; break;
       case 'security': result = this._computeSecurityApiModel(model, selected); break;
       case 'type': result = this._computeTypeApiModel(model, selected); break;
       case 'documentation': result = this._computeDocsApiModel(model, selected); break;
@@ -625,6 +626,10 @@ class ApiDocumentation extends EventsTargetMixin(AmfHelperMixin(LitElement)) {
         } else {
           result = this._computeMethodApiModel(model, selected);
           this._endpoint = this._computeEndpointApiMethodModel(model, selected);
+        }
+        if (!result) { // if method does not exist in model should navigate to summary
+          this.selected = summary;
+          this.selectedType = summary;
         }
         break;
       default:

--- a/demo/APIC-392/APIC-392.raml
+++ b/demo/APIC-392/APIC-392.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0
+title: test
+
+traits:
+  testtrait: !include trait/testtrait.raml
+
+/testrequest:
+  displayName: Company Monitoring
+  is: [testtrait]   
+  get:
+    displayName: simple Get
+    description: Adds an organisation to Monitoring for the given profile
+    responses: 
+      202:

--- a/demo/APIC-392/trait/testtrait.raml
+++ b/demo/APIC-392/trait/testtrait.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 Trait
+usage: test
+queryParameters: 
+  testType: 
+    description: a test in use case
+    enum: [param1, param2, param3]
+    default: param3

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -14,5 +14,6 @@
   "SE-11415/SE-11415.raml": "RAML 1.0",
   "exchange-experience-api/exchange-experience-api.raml": "RAML 0.8",
   "google-drive-api/google-drive-api.raml": "RAML 1.0",
+  "APIC-392/APIC-392.raml": "RAML 1.0",
   "multi-server/multi-server.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }


### PR DESCRIPTION
Bug: When some method is selected and model changes, it can result in a non-existent selected method id in the new model. The method view will be empty.

Fix: When invalid method id is selected, navigate to default panel as is summary