### PR TITLE
Compute media types when not enclosed in `@value` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,11 +34,11 @@
       }
     },
     "@advanced-rest-client/arc-events": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-events/-/arc-events-0.2.14.tgz",
-      "integrity": "sha512-wP5m2nB1DzhDZX1CI1xR/6jmpPfSmxdjkU+T/g/esxR28ikrWmk05FitAgbkXDRuqr1Roj50r7PnaepqilH+Mw==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-events/-/arc-events-0.2.17.tgz",
+      "integrity": "sha512-W0Zj5gaSW60T3nv0nV3u+ylWTireX8Kov2U00APKeiGVmQR6Ht9X6W2VdLhiT4L6hAChQQchhEGcB8N5tKdn4Q==",
       "requires": {
-        "@advanced-rest-client/arc-types": "^0.2.49"
+        "@advanced-rest-client/arc-types": "^0.2.52"
       }
     },
     "@advanced-rest-client/arc-fit-mixin": {
@@ -80,13 +80,13 @@
       }
     },
     "@advanced-rest-client/arc-marked": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-marked/-/arc-marked-1.1.1.tgz",
-      "integrity": "sha512-gG+pd5GgYy4SvpA6hP4V5udi8BXgCRoctOgruMum/1zbMOWNc6ccjtEQT7C+p4CJ12rv+2L9LPCDdQQXw/ME5Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-marked/-/arc-marked-1.1.2.tgz",
+      "integrity": "sha512-YHi4aGGh8XFjLi4N0szqOBmtGiC6wn+UCB5josEhAP/oVwlRnWxSCNenwjvpINO+RJ8Dr09Ed5dVMGS/wz4yCw==",
       "requires": {
-        "dompurify": "^2.2.7",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0",
+        "dompurify": "^2.2.9",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1",
         "marked": "^0.7.0"
       }
     },
@@ -115,9 +115,9 @@
       }
     },
     "@advanced-rest-client/arc-resizable-mixin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-resizable-mixin/-/arc-resizable-mixin-1.2.1.tgz",
-      "integrity": "sha512-ZRYsgq7FTjU0EnBWsoTbS30LwzsusZY4K7xoLnXWU9x1vHeFuezh4JAG73Z3FKLcIyxxi3CTSjuPsuyIjJk++A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-resizable-mixin/-/arc-resizable-mixin-1.2.2.tgz",
+      "integrity": "sha512-Z7+dfxTP7nqPgfxVgYduUVVg2ApTw767zYL1SRpUZx/v2AMZsSXB1bvWqVCatAzpQPNcZwWbCTChtwL5Nh7omQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0"
       }
@@ -144,9 +144,9 @@
       }
     },
     "@advanced-rest-client/arc-types": {
-      "version": "0.2.50",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-types/-/arc-types-0.2.50.tgz",
-      "integrity": "sha512-dM8IMwBFNB63nAOJLJoTTCITNvHOSbPi2YrxhtvLgXE+L4LE/AemxHjlF4cFDBZx9qpmrLgXpGjm3ltIi42d8w=="
+      "version": "0.2.52",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-types/-/arc-types-0.2.52.tgz",
+      "integrity": "sha512-TmTudK0A+P8+4yScZXvw3eRN9gqq5C8QWlnEjPKtCHEztZL7BKcymTGIXER/CerWuroLItZ6CSFDSxUM5wq99Q=="
     },
     "@advanced-rest-client/arc-url": {
       "version": "0.1.7",
@@ -170,29 +170,33 @@
         "lit-html": "^1.3.0"
       }
     },
-    "@advanced-rest-client/authorization-method": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/authorization-method/-/authorization-method-0.2.6.tgz",
-      "integrity": "sha512-/YjMLjNUj2x1rGVDuF+n5Vu0IYiU1V+/AAgW1RzCNFUAI9Uf5H2KILBDUkJKqtO378L9V60Ikd7kNBFNJstKLA==",
+    "@advanced-rest-client/authorization": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/authorization/-/authorization-0.1.0.tgz",
+      "integrity": "sha512-CldG5iIAg2cWbZLPsowEXhBpPVjv4MBf38ccLZykGj666Z/cZiD0WbHsDyuA62qjMpUzoi3AJqgaztdSDhDxxw==",
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.14",
+        "@advanced-rest-client/arc-events": "^0.2.17",
+        "@advanced-rest-client/arc-headers": "^0.1.10",
         "@advanced-rest-client/arc-icons": "^3.3.0",
-        "@advanced-rest-client/arc-types": "^0.2.49",
+        "@advanced-rest-client/arc-types": "^0.2.52",
         "@advanced-rest-client/clipboard-copy": "^3.0.1",
         "@advanced-rest-client/events-target-mixin": "^3.2.3",
-        "@advanced-rest-client/oauth2-scope-selector": "^4.0.0",
-        "@anypoint-web-components/anypoint-button": "^1.2.0",
-        "@anypoint-web-components/anypoint-checkbox": "^1.1.3",
+        "@anypoint-web-components/anypoint-autocomplete": "^0.2.10",
+        "@anypoint-web-components/anypoint-button": "^1.2.1",
+        "@anypoint-web-components/anypoint-checkbox": "^1.2.1",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-dialog": "^0.1.7",
-        "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.20",
-        "@anypoint-web-components/anypoint-input": "^0.2.24",
-        "@anypoint-web-components/anypoint-item": "^1.1.0",
-        "@anypoint-web-components/anypoint-listbox": "^1.1.6",
-        "@anypoint-web-components/anypoint-switch": "^0.1.4",
+        "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.21",
+        "@anypoint-web-components/anypoint-input": "^0.2.25",
+        "@anypoint-web-components/anypoint-item": "^1.1.2",
+        "@anypoint-web-components/anypoint-listbox": "^1.1.7",
+        "@anypoint-web-components/anypoint-selector": "^1.1.7",
+        "@anypoint-web-components/anypoint-switch": "^0.1.10",
+        "@anypoint-web-components/validatable-mixin": "^1.1.3",
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/paper-spinner": "^3.0.2",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@advanced-rest-client/body-editor": {
@@ -283,9 +287,9 @@
       }
     },
     "@advanced-rest-client/form-data-editor": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/form-data-editor/-/form-data-editor-3.0.7.tgz",
-      "integrity": "sha512-x/zUrwt3JCXioxHkpUKrpv/BtKVj5YREV0Eqid8RJSpypZS1fp7ylWrvVl1G82pwkRdmlIiQVgRj+rjn9Y3PTA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/form-data-editor/-/form-data-editor-3.0.10.tgz",
+      "integrity": "sha512-rbQk4CQHLBDhgw+NLVxa6pajC7ztqhblxkun3ov+1wBMmgeqSHMh3ycXL240Nfg98LVoI0YznVwaQsVbonj7iw==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.0.2",
         "@advanced-rest-client/arc-marked": "^1.0.4",
@@ -294,6 +298,7 @@
         "@anypoint-web-components/anypoint-button": "^1.0.12",
         "@anypoint-web-components/anypoint-checkbox": "^1.0.1",
         "@anypoint-web-components/anypoint-input": "^0.2.5",
+        "@anypoint-web-components/anypoint-switch": "^0.1.9",
         "@anypoint-web-components/validatable-mixin": "^1.0.2",
         "@api-components/api-form-mixin": "^3.0.3",
         "@api-components/api-property-form-item": "^3.0.9",
@@ -369,25 +374,26 @@
       }
     },
     "@advanced-rest-client/multipart-payload-editor": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/multipart-payload-editor/-/multipart-payload-editor-4.1.1.tgz",
-      "integrity": "sha512-KnwdOmuYx7F8x/PEu/LwR5iCMGMovTF3MLcwrgbKZCEQvuoDbJ4CjXm9bpxTyuBgDNbmmn9tCk9wbQD+lGAqeg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/multipart-payload-editor/-/multipart-payload-editor-4.1.4.tgz",
+      "integrity": "sha512-kQegUGxF3ucB3F6V3nKtpujCKyg5ZE/Cg8tRoQ+OXlP+qzq7Fmw39rqaelLgU9wGM5O6LbpChcQhoY7irLdWeA==",
       "requires": {
-        "@advanced-rest-client/arc-icons": "^3.0.5",
-        "@advanced-rest-client/arc-marked": "^1.0.6",
-        "@advanced-rest-client/clipboard-copy": "^3.0.1",
-        "@advanced-rest-client/markdown-styles": "^3.1.2",
+        "@advanced-rest-client/arc-icons": "^3.3.3",
+        "@advanced-rest-client/arc-marked": "^1.1.1",
+        "@advanced-rest-client/clipboard-copy": "^3.1.0",
+        "@advanced-rest-client/markdown-styles": "^3.1.5",
         "@advanced-rest-client/multipart-payload-transformer": "^3.0.0",
-        "@advanced-rest-client/prism-highlight": "^4.0.2",
-        "@anypoint-web-components/anypoint-button": "^1.0.15",
-        "@anypoint-web-components/anypoint-input": "^0.2.14",
-        "@anypoint-web-components/validatable-mixin": "^1.0.2",
-        "@api-components/api-form-mixin": "^3.0.4",
-        "@api-components/api-property-form-item": "^3.0.12",
-        "@api-components/api-view-model-transformer": "^4.1.0",
-        "@polymer/iron-form": "^3.0.0",
-        "@polymer/paper-toast": "^3.0.0",
-        "@polymer/prism-element": "^3.0.0",
+        "@advanced-rest-client/prism-highlight": "^4.1.2",
+        "@anypoint-web-components/anypoint-button": "^1.2.1",
+        "@anypoint-web-components/anypoint-input": "^0.2.25",
+        "@anypoint-web-components/anypoint-switch": "^0.1.9",
+        "@anypoint-web-components/validatable-mixin": "^1.1.3",
+        "@api-components/api-form-mixin": "^3.1.3",
+        "@api-components/api-property-form-item": "^3.0.16",
+        "@api-components/api-view-model-transformer": "^4.2.2",
+        "@polymer/iron-form": "^3.0.1",
+        "@polymer/paper-toast": "^3.0.1",
+        "@polymer/prism-element": "^3.0.1",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1",
         "prismjs": "^1.20.0"
@@ -402,32 +408,16 @@
       }
     },
     "@advanced-rest-client/oauth-authorization": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/oauth-authorization/-/oauth-authorization-5.0.5.tgz",
-      "integrity": "sha512-FAoxyiRMNYlV2HEH7G9WhGsz+kBm6Xi1AiZUD6628VL/+hnswDnp+NkCjeDOmtoLUwXHtTDqsHu+JOayEYSEQw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/oauth-authorization/-/oauth-authorization-5.0.6.tgz",
+      "integrity": "sha512-JBp1QDtLVfJK9XsvIK60CTs7unZBa2i+MBHzMqGhqIsUJ1mw60GuuJ8MqzDZQGAhKC0X4HhkmosygbkiVRRVvw==",
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.14",
-        "@advanced-rest-client/arc-types": "^0.2.49",
+        "@advanced-rest-client/arc-events": "^0.2.17",
+        "@advanced-rest-client/arc-types": "^0.2.52",
         "@advanced-rest-client/events-target-mixin": "^3.2.3",
         "@advanced-rest-client/headers-parser-mixin": "^3.2.0",
         "@polymer/iron-meta": "^3.0.0",
-        "lit-element": "^2.4.0"
-      }
-    },
-    "@advanced-rest-client/oauth2-scope-selector": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/oauth2-scope-selector/-/oauth2-scope-selector-4.0.2.tgz",
-      "integrity": "sha512-iu6UOXf1meBtse6TOBFVNPekEOidr8Tjrgw7dQjlzI0WhdI+ropyj4H2GbV+A1jGxzpygMdwa3t0EjCKDGG8Lg==",
-      "requires": {
-        "@advanced-rest-client/arc-icons": "^3.1.2",
-        "@anypoint-web-components/anypoint-autocomplete": "^0.2.7",
-        "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "@anypoint-web-components/anypoint-input": "^0.2.22",
-        "@anypoint-web-components/validatable-mixin": "^1.1.3",
-        "@polymer/paper-toast": "^3.0.0",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1"
       }
     },
     "@advanced-rest-client/payload-parser-mixin": {
@@ -480,12 +470,12 @@
       }
     },
     "@advanced-rest-client/prism-highlight": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/prism-highlight/-/prism-highlight-4.1.2.tgz",
-      "integrity": "sha512-m7VCyHaukh757bX6eL03PwiuEyXyz0RsKiNRPyeP2oADiaMjCz+pm/rYzeDjQjP30eNp+uzVjXnwpht6SqqzGA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/prism-highlight/-/prism-highlight-4.1.3.tgz",
+      "integrity": "sha512-o0lxDi6+Tt4e3tsJ11cCuVWPT+R4yj97ZCyME6oRuJopwQoOkY2t2V3SMfL2yQqtXvU9MD5t73wVPnBMEeCW2Q==",
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.14",
-        "lit-element": "^2.4.0",
+        "@advanced-rest-client/arc-events": "^0.2.17",
+        "lit-element": "^2.5.1",
         "prismjs": "^1.23.0"
       }
     },
@@ -510,32 +500,30 @@
       "integrity": "sha512-eP3Yo04FiQao7mPEhG37ESG1zYNB5uQ03dB3FlCvaZoUs4qGduBr7SRHdFENcGJlxCkwhY0QVKFfuaZZValPTA=="
     },
     "@anypoint-web-components/anypoint-autocomplete": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-autocomplete/-/anypoint-autocomplete-0.2.9.tgz",
-      "integrity": "sha512-+TWRnOQK2csn+iyqmLI/2cacKlPZARJXlt9GTj57lCIi9+TUs4Ak8Q7XwWVbHlNSw/9nuAGEjXvxwMVpVTd/kQ==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-autocomplete/-/anypoint-autocomplete-0.2.10.tgz",
+      "integrity": "sha512-f8bZbQgXJuLRyG1v4nAHqS0Q5jqI3cPs4FmoxSq39oL1H1fxA9/LcdeWQxPiom0x/XcDXub2R7+x/AhEt0oSVw==",
       "requires": {
-        "@anypoint-web-components/anypoint-dropdown": "^1.1.5",
-        "@anypoint-web-components/anypoint-item": "^1.1.0",
-        "@anypoint-web-components/anypoint-listbox": "^1.1.6",
-        "@polymer/paper-progress": "^3.0.0",
-        "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.4.0"
+        "@anypoint-web-components/anypoint-dropdown": "^1.1.6",
+        "@anypoint-web-components/anypoint-item": "^1.1.2",
+        "@anypoint-web-components/anypoint-listbox": "^1.1.7",
+        "lit-element": "^2.5.1"
       }
     },
     "@anypoint-web-components/anypoint-button": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.2.0.tgz",
-      "integrity": "sha512-z3og4oxSlwo37ISbg4S32/NeOqtJcsEfAk4CQ1c4tJM/TsI+lTFLZHwNELeunRg8yoGGnjhrnrxTbin+YKfYBQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.2.2.tgz",
+      "integrity": "sha512-exxGQ3TI2IBxxCgd1FCPJy4C+PKopL9eoofbFSKWGnqgYK1QsBOo1BH9dlj7pXgd7GAvjyJux2sDAs57oiAU/g==",
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.4.0"
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "@anypoint-web-components/material-ripple": "^1.0.1",
+        "lit-element": "^2.5.1"
       }
     },
     "@anypoint-web-components/anypoint-checkbox": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-checkbox/-/anypoint-checkbox-1.2.0.tgz",
-      "integrity": "sha512-DB1sCsv+me4lDMeSONP3YVBDJT0w62egLgqooJaHsD5N4Xyutv+rysJvLawripdY4E8GqN+RyE6EvOPqeJEV4g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-checkbox/-/anypoint-checkbox-1.2.1.tgz",
+      "integrity": "sha512-HoLMfQDBUnEpEp1Qni0lqpcqwSgbZDgpzUgzG5Nrly3T/z9F+ZCm8DdD2cBEW0sAO08U5/SgvItcP4qpsWF6Mw==",
       "requires": {
         "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-form-mixins": "^1.3.0",
@@ -543,13 +531,13 @@
       }
     },
     "@anypoint-web-components/anypoint-collapse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-collapse/-/anypoint-collapse-0.1.1.tgz",
-      "integrity": "sha512-SwDejIKoALg2k72SFiMV09vuzkLJjlAM3oa99tIH5UMHl+tDeMBk+L9xCLzyYZCaHO52eP8AKeFftvIrpENWKw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-collapse/-/anypoint-collapse-0.1.2.tgz",
+      "integrity": "sha512-+arHE/rxvtXLs01R9XNrLPWEO5n7f8KcmvKhiq7Er5pqt49O6VbZIcdqEHiuhRigjsObE3/x0SP4OMuDMrO9fw==",
       "requires": {
         "@advanced-rest-client/arc-resizable-mixin": "^1.2.0",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-control-mixins": {
@@ -572,14 +560,14 @@
       }
     },
     "@anypoint-web-components/anypoint-dropdown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown/-/anypoint-dropdown-1.1.5.tgz",
-      "integrity": "sha512-hpj83EjrzI3uoGi6/B96h5cLghZB1YE6sdlNd6Z9tBlnXb1X2/9EuGn0JZGQlRHy++dRiLoM9vfEcn/AiEfYFQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dropdown/-/anypoint-dropdown-1.1.6.tgz",
+      "integrity": "sha512-pYbyAud5HnkeSiR+jy4pYbf0O+dBySApITzvqw3aAL1P+OiiSuOlHg+ghYL4q4HQCWF5rRhu+Hiv8CrVcS/bkQ==",
       "requires": {
         "@advanced-rest-client/arc-overlay-mixin": "^1.2.0",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-dropdown-menu": {
@@ -605,23 +593,23 @@
       }
     },
     "@anypoint-web-components/anypoint-input": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.24.tgz",
-      "integrity": "sha512-IFxwuolKXBtGDmWGqfmdlJwzGlAJr7fE56tNqMrdqCNHEEJvxcWBxIXiWDfnN7SctuqQDkX1Oz+o9wIe3k2tlw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.26.tgz",
+      "integrity": "sha512-RM2TlByYvwdeE6SO5/cMmvTkr8YqMynXkECq49qvktNZ9H2D9KVYkDkzAYrBwznWuea5AW/IRyUVuzVXEA9SBA==",
       "requires": {
-        "@advanced-rest-client/arc-icons": "^3.1.2",
-        "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
+        "@advanced-rest-client/arc-icons": "^3.3.3",
+        "@anypoint-web-components/anypoint-button": "^1.2.1",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/validatable-mixin": "^1.1.3",
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-item": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.1.1.tgz",
-      "integrity": "sha512-ZfMdrz6T0tXl+shLD2ScXVpP9MaeuHvgEMi4ArvK9/vqtwgB6d3ftZ2+YpqW+R/sxj2X8tYWun6fcvA0fpJ9uA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.1.2.tgz",
+      "integrity": "sha512-AD702ZKg6AW+0wUlE/UHMLcVUGlwgDXRjhmtMSH5vp1gGBbg4OzhiUN8/kwLiWIC5O4yyikUBpFmuD09VGQc1A==",
       "requires": {
         "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
@@ -630,13 +618,13 @@
       }
     },
     "@anypoint-web-components/anypoint-listbox": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-listbox/-/anypoint-listbox-1.1.6.tgz",
-      "integrity": "sha512-YkQuORirn6k+erAeB1H1OZgFqc7gOPcGaJoH+TuXW8Sb5gdburU8UtdTnO9CvZ/a+pCcIE35EgrdcInBglXGiQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-listbox/-/anypoint-listbox-1.1.7.tgz",
+      "integrity": "sha512-F4VueUMEdH8unfJ5Wyqv4QO8Cfl/F1lkq0o7vrKPafYyK455ArIx1CCsgUUUhXAG8+T4WZie5xfnqVRr+uYWpA==",
       "requires": {
         "@anypoint-web-components/anypoint-menu-mixin": "^1.1.7",
-        "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0"
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
       }
     },
     "@anypoint-web-components/anypoint-menu-button": {
@@ -662,9 +650,9 @@
       }
     },
     "@anypoint-web-components/anypoint-radio-button": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.7.tgz",
-      "integrity": "sha512-lwQYTbq+bv8V3K3KYCTyMhyrT2NKw6RgXqITzzHuWtXq4MVM/Z6IuY4LWr9mUgpcgjXXpQ5DZXs1HJK1EOqUCg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-radio-button/-/anypoint-radio-button-0.1.8.tgz",
+      "integrity": "sha512-2F9xXI/U13jBBjd0kJRewM5O1gbrrowr8rhdcDMVXVg8gTtUYdcnN8B4SMudJo9v0tUdBROnBESba6Q5nJEnlQ==",
       "requires": {
         "@anypoint-web-components/anypoint-form-mixins": "^1.2.2",
         "@anypoint-web-components/anypoint-menu-mixin": "^1.1.8",
@@ -692,9 +680,9 @@
       }
     },
     "@anypoint-web-components/anypoint-switch": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-switch/-/anypoint-switch-0.1.9.tgz",
-      "integrity": "sha512-EUqx7qinTGTCozjFa7B/3455vy9I96CEV2wZMC4KkMciOvIqRBVKw6XihL0XAKMoe7xBHjfNUHAdg595ts4wyQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-switch/-/anypoint-switch-0.1.10.tgz",
+      "integrity": "sha512-EXE+6nF52TBOcx8sXDLmVmR9jliZzsG3zsPm6BFbWLofO0E6ZqPy7y6+yhyaIMCyl8M5GZWE9n+w7oyDQvELxQ==",
       "requires": {
         "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-form-mixins": "^1.3.0",
@@ -702,17 +690,26 @@
       }
     },
     "@anypoint-web-components/anypoint-tabs": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-tabs/-/anypoint-tabs-0.1.17.tgz",
-      "integrity": "sha512-hBAoU0hjp8GusWKK/F2Urt1OvCn7KgEfOdYUahjb6u242lvUkOaMfP9kD1Qp92fRa9mA/wjL7tsNtnWeZ7hTQQ==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-tabs/-/anypoint-tabs-0.1.19.tgz",
+      "integrity": "sha512-h3slAS0XjdSbN+NM/FlNsw2Je81MrrPncw51dHr3Zw97KwncwlZlzFn/cJJo0lQaN6dxB6X4Hh646Qa/mN8UIg==",
       "requires": {
-        "@advanced-rest-client/arc-resizable-mixin": "^1.2.1",
-        "@anypoint-web-components/anypoint-button": "^1.2.0",
+        "@advanced-rest-client/arc-resizable-mixin": "^1.2.2",
+        "@anypoint-web-components/anypoint-button": "^1.2.1",
         "@anypoint-web-components/anypoint-control-mixins": "^1.2.0",
         "@anypoint-web-components/anypoint-menu-mixin": "^1.1.8",
-        "@polymer/paper-ripple": "^3.0.2",
+        "@anypoint-web-components/material-ripple": "^1.0.1",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1"
+      }
+    },
+    "@anypoint-web-components/material-ripple": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/material-ripple/-/material-ripple-1.0.2.tgz",
+      "integrity": "sha512-gGjKwfAFroX1NAL37z/FWan2hofKylx7yxb8+/hac6/wNht3iixzlHQQ1JolYfN6Q/Z40nRu4p50ylel9v2Diw==",
+      "requires": {
+        "@advanced-rest-client/arc-icons": "^3.3.3",
+        "lit-element": "^2.4.0"
       }
     },
     "@anypoint-web-components/validatable-mixin": {
@@ -752,20 +749,20 @@
       }
     },
     "@api-components/api-authorization": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-authorization/-/api-authorization-0.6.1.tgz",
-      "integrity": "sha512-DJJ+Vu9Q/Qsa2Wh/mfbTA+7+Dig3jtXe3mR7+tteMF6lUq3XyjkA4JrmpbedOByjsZ1Y6MyHm4I2qkhYTdrMew==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@api-components/api-authorization/-/api-authorization-0.6.3.tgz",
+      "integrity": "sha512-gDVsZS/+ctKBSR5m6o9fWBwQ6FY6eVbPdVpz7H96U4FK1pnmtyU7zOwXiJk+W+RSKXM0WpPWpVr5bXa/9y0Lcw==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
         "@advanced-rest-client/arc-marked": "^1.1.0",
         "@advanced-rest-client/arc-types": "^0.2.47",
-        "@advanced-rest-client/authorization-method": "^0.2.5",
+        "@advanced-rest-client/authorization": "^0.1.0",
         "@advanced-rest-client/events-target-mixin": "^3.1.1",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
         "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.14",
         "@anypoint-web-components/anypoint-item": "^1.0.5",
         "@anypoint-web-components/anypoint-listbox": "^1.0.4",
-        "@api-components/amf-helper-mixin": "^4.3.4",
+        "@api-components/amf-helper-mixin": "^4.4.0",
         "@api-components/api-forms": "^0.2.1",
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit-element": "^2.3.1",
@@ -850,9 +847,9 @@
       }
     },
     "@api-components/api-example-generator": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.9.tgz",
-      "integrity": "sha512-nz6CwIVYu67CKLI++ZO5h6xy0EUBfY2smR/dv2J35iOchs3QG2jHhCAwEwX3DCjkl8vy8fhv38bvBBPwi8Ixag==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@api-components/api-example-generator/-/api-example-generator-4.4.10.tgz",
+      "integrity": "sha512-3KZDIteCnVEBPGH0+BQalYB2I4FyazeXW7z10w9aektEMsJWoWH6RnZrc4+63zBRKrB5w1uMDjxRXChsYmJdHQ==",
       "requires": {
         "@api-components/amf-helper-mixin": "^4.1.8",
         "lit-element": "^2.4.0"
@@ -868,9 +865,9 @@
       }
     },
     "@api-components/api-forms": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@api-components/api-forms/-/api-forms-0.2.1.tgz",
-      "integrity": "sha512-KPtNn/UxbQKaN09l8k2edWt8T3KEXo3IVFBP85/zvkmH+suqyC0rIXmVoJ5iffvI0H4tgaEnTLUyI5WA++8gVw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@api-components/api-forms/-/api-forms-0.2.2.tgz",
+      "integrity": "sha512-I7yAWEtQuq6SO/+IwXlgNypeYOCQsUjVJXnxYNEGNsRw1E7idT2TtwzP1bI5YZTK4cdVKatFjDHneeHGpZYzYQ==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
         "@advanced-rest-client/arc-types": "^0.2.47",
@@ -940,38 +937,19 @@
       }
     },
     "@api-components/api-model-generator": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.2.11.tgz",
-      "integrity": "sha512-tpY9QJjkxeZrwFSzBCfjDk910gjqXSWw/aDRWAiKCLPctdbkSOuv5jwhIeHLBst2bISS/eR+YmxRXv1cASwoQw==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@api-components/api-model-generator/-/api-model-generator-0.2.13.tgz",
+      "integrity": "sha512-G92MvXqWBVh7KNbYGto7vg5grMbUGBYKyZw8X2WSp2b4VwholspY9zMzqZA+Zpwrt9lK8RvPLkbaLWi4micyvQ==",
       "dev": true,
       "requires": {
-        "amf-client-js": "^4.7.3-1",
+        "amf-client-js": "^4.7.4",
         "fs-extra": "^10.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
       }
     },
     "@api-components/api-navigation": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.2.8.tgz",
-      "integrity": "sha512-biv4bYyiLW0VSNVkeW73ZpZ1wuT9yoCEIQ8jFIOxzZ0syQc587gSfim+4zdj+FAFAGooU3Z3nN40KVXJpzubKg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.3.0.tgz",
+      "integrity": "sha512-UacbF1lpInkUuwKRFFdla+1PQmi89+GDiUFhuTUGVRncj5O+kNllni7SWa8hR4kdNZczn/Nv8pCD1tYzYxtWfA==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -1015,9 +993,9 @@
       }
     },
     "@api-components/api-request": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.1.15.tgz",
-      "integrity": "sha512-d/SY2fQcjMogDm5daOV0tBAgb4iCayg32Jvmo5vK2v/279NPle1be9V7ABYwIL3OWdrllR9XzItg0Sp+BWUO1g==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.1.16.tgz",
+      "integrity": "sha512-pKEQYCx4OXmqBeS/v3m3E0gK6LJH4a1sfLp1s0vOTYMhjEF0fkLr0GpKkTZEO155g9Ewa4y26iX2tafYZZSEqg==",
       "requires": {
         "@advanced-rest-client/arc-events": "^0.2.13",
         "@advanced-rest-client/arc-headers": "^0.1.7",
@@ -1134,13 +1112,6 @@
         "dompurify": "^2.2.9",
         "lit-element": "^2.5.1",
         "lit-html": "^1.4.1"
-      },
-      "dependencies": {
-        "dompurify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
-          "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
-        }
       }
     },
     "@api-components/api-type-document": {
@@ -1171,30 +1142,12 @@
         "@api-components/api-schema-document": "^4.3.0",
         "@api-components/api-type-document": "^4.2.13",
         "lit-element": "^2.5.1"
-      },
-      "dependencies": {
-        "@advanced-rest-client/arc-marked": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-marked/-/arc-marked-1.1.2.tgz",
-          "integrity": "sha512-YHi4aGGh8XFjLi4N0szqOBmtGiC6wn+UCB5josEhAP/oVwlRnWxSCNenwjvpINO+RJ8Dr09Ed5dVMGS/wz4yCw==",
-          "requires": {
-            "dompurify": "^2.2.9",
-            "lit-element": "^2.5.1",
-            "lit-html": "^1.4.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "dompurify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
-          "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
-        }
       }
     },
     "@api-components/api-url": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@api-components/api-url/-/api-url-0.1.8.tgz",
-      "integrity": "sha512-YSpuUMfUK8fWoxI2taix6yFJSCd845mC1ZJZJYg19z6fXdVRffcF2HPu3g/c1SlECxkYok9bVhrhFnWNai2jHQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@api-components/api-url/-/api-url-0.1.9.tgz",
+      "integrity": "sha512-CVe8ksEMCLZFNN/VlPvyFXqeNaDqG84cyoJbDX7hmDWHtfJfzAYivv9P/Wcx8S4uTcgAptK28iUKYRsKUi9oLA==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
         "@advanced-rest-client/arc-types": "^0.2.47",
@@ -1235,27 +1188,27 @@
       "integrity": "sha512-lWIjd8Wq6tYJmF8ZXyUgQdGq+vhXP7pKY/QcPQdKOn2IXb4/gqTglebtXnxjME41+uKSPQoMSKTEVT/PwX93qQ=="
     },
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -1298,21 +1251,21 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz",
-      "integrity": "sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz",
+      "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
       "dev": true,
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -1504,6 +1457,26 @@
         "@commitlint/types": "^12.1.4",
         "fs-extra": "^9.0.0",
         "git-raw-commits": "^2.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -1681,9 +1654,9 @@
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.21.1.tgz",
-      "integrity": "sha512-dJlBz8/nQgxH5ARkh8/092BbvQ8vaJ38hjWinLXXakmdj8WsVHnhUJ7/D4YtqY61bjwCBFekOLSPjfxKCEMRgA==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.21.3.tgz",
+      "integrity": "sha512-DX/IECNsUpMXNgZyz8e5d/Bpq9PSmlABs7rUqkMVXgqhnOO0KvJOEuWu4P9+ONlkbzqK4O7DKMi6gw3GkKI3OA==",
       "dev": true,
       "requires": {
         "@comunica/context-entries": "^1.21.1",
@@ -1700,34 +1673,34 @@
       "dev": true
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.1.tgz",
-      "integrity": "sha512-lDiMgpktwg/bzKAZip+s8k6Y7LDYfkYuqo3i1ZD+EdgUm484yuMo7K3Y21P2C04w5FazYAbnx7AzEj1hrdc0iA==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.21.3.tgz",
+      "integrity": "sha512-R7auYy7gppLt0nUAc+Y+3mjYmwaLzr02PTx9XGO/ojUi/LnCuU2lrS2Fik90b9N3kg5kDJYN/znT/XHpy5vdGg==",
       "dev": true,
       "requires": {
         "@comunica/actor-abstract-bindings-hash": "^1.21.1",
         "@comunica/actor-abstract-mediatyped": "^1.21.1",
         "@comunica/actor-context-preprocess-source-to-destination": "^1.21.1",
         "@comunica/actor-http-memento": "^1.21.1",
-        "@comunica/actor-http-native": "^1.21.1",
+        "@comunica/actor-http-native": "^1.21.3",
         "@comunica/actor-http-proxy": "^1.21.1",
         "@comunica/actor-optimize-query-operation-join-bgp": "^1.21.1",
         "@comunica/actor-query-operation-ask": "^1.21.1",
         "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
         "@comunica/actor-query-operation-bgp-single": "^1.21.1",
         "@comunica/actor-query-operation-construct": "^1.21.1",
         "@comunica/actor-query-operation-describe-subject": "^1.21.1",
         "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
-        "@comunica/actor-query-operation-extend": "^1.21.1",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
         "@comunica/actor-query-operation-from-quad": "^1.21.1",
         "@comunica/actor-query-operation-group": "^1.21.1",
         "@comunica/actor-query-operation-join": "^1.21.1",
         "@comunica/actor-query-operation-leftjoin-left-deep": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
         "@comunica/actor-query-operation-minus": "^1.21.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
         "@comunica/actor-query-operation-path-alt": "^1.21.1",
         "@comunica/actor-query-operation-path-inv": "^1.21.1",
         "@comunica/actor-query-operation-path-link": "^1.21.1",
@@ -1741,7 +1714,7 @@
         "@comunica/actor-query-operation-reduced-hash": "^1.21.1",
         "@comunica/actor-query-operation-service": "^1.21.1",
         "@comunica/actor-query-operation-slice": "^1.21.1",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.21.2",
         "@comunica/actor-query-operation-union": "^1.21.1",
         "@comunica/actor-query-operation-update-add-rewrite": "^1.21.1",
         "@comunica/actor-query-operation-update-clear": "^1.21.1",
@@ -1754,7 +1727,7 @@
         "@comunica/actor-query-operation-update-move-rewrite": "^1.21.1",
         "@comunica/actor-query-operation-values": "^1.21.1",
         "@comunica/actor-rdf-dereference-fallback": "^1.21.1",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.21.1",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.21.2",
         "@comunica/actor-rdf-join-multi-smallest": "^1.21.1",
         "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
         "@comunica/actor-rdf-join-symmetrichash": "^1.21.1",
@@ -1762,13 +1735,13 @@
         "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.21.1",
         "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.21.1",
         "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.21.1",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.1",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.21.2",
         "@comunica/actor-rdf-metadata-primary-topic": "^1.21.1",
         "@comunica/actor-rdf-parse-html": "^1.21.1",
         "@comunica/actor-rdf-parse-html-microdata": "^1.21.1",
         "@comunica/actor-rdf-parse-html-rdfa": "^1.21.1",
         "@comunica/actor-rdf-parse-html-script": "^1.21.1",
-        "@comunica/actor-rdf-parse-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-parse-jsonld": "^1.21.2",
         "@comunica/actor-rdf-parse-n3": "^1.21.1",
         "@comunica/actor-rdf-parse-rdfxml": "^1.21.1",
         "@comunica/actor-rdf-parse-xml-rdfa": "^1.21.1",
@@ -1776,7 +1749,7 @@
         "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.21.1",
         "@comunica/actor-rdf-resolve-hypermedia-none": "^1.21.1",
         "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.21.1",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.1",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.21.2",
         "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.21.1",
         "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.21.1",
         "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
@@ -1843,26 +1816,26 @@
       }
     },
     "@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.21.1.tgz",
-      "integrity": "sha512-QWbZIb2QW99r5hL168kO3cJGjr1c0kviDndNU+ttqHE1iyCBdZikxhIm+njzTWSQcFFUntHqmfofNxd3hUbf/A==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.21.3.tgz",
+      "integrity": "sha512-x2LWKS/qRGZetZGiKGKzKEYr/yb6nEw4KGPbpYo6N4Jp0BvTigiEPYx3HhOaEjeYCONgd/3j3JO5vefFIFNE2w==",
       "dev": true,
       "requires": {
         "@comunica/actor-abstract-mediatyped": "^1.21.1",
-        "@comunica/actor-init-sparql": "^1.21.1",
+        "@comunica/actor-init-sparql": "^1.21.3",
         "@comunica/actor-query-operation-ask": "^1.21.1",
         "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
         "@comunica/actor-query-operation-bgp-single": "^1.21.1",
         "@comunica/actor-query-operation-construct": "^1.21.1",
         "@comunica/actor-query-operation-describe-subject": "^1.21.1",
         "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
-        "@comunica/actor-query-operation-extend": "^1.21.1",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
         "@comunica/actor-query-operation-from-quad": "^1.21.1",
         "@comunica/actor-query-operation-join": "^1.21.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
         "@comunica/actor-query-operation-path-alt": "^1.21.1",
         "@comunica/actor-query-operation-path-inv": "^1.21.1",
         "@comunica/actor-query-operation-path-link": "^1.21.1",
@@ -1937,9 +1910,9 @@
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.21.1.tgz",
-      "integrity": "sha512-yLtvCj9gkmWNdqTT3SuQwSJh21/1eR0vjDpRcQA5P/HlCPARKJT6OBbWisaH1JNygHptw/oKnoPZKPsWVB/cEA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.21.2.tgz",
+      "integrity": "sha512-7QTQiHFbdZcTxv35SddFzorBuvoQio7KXY/z0hU/JoFr0vx5qtZQFXwrl0dt41xqnJkFGcv1s7U3Zx6Rc1uQZQ==",
       "dev": true,
       "requires": {
         "@comunica/context-entries": "^1.21.1",
@@ -2003,9 +1976,9 @@
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.21.1.tgz",
-      "integrity": "sha512-xxUQB50GRXxFNNKWREvmBxjycua5aGnW+VebyKGY7jJRc/wurF7RCvKPXy3FoSQYKF8MhJ3VnSP5hRvKW9IKmA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.21.2.tgz",
+      "integrity": "sha512-dXL7Lrp09CZUU8T6EMXaf4eAMzcSsMpIS5XvU+LjF9u9vMjkTU2EmTpeW5l0WoWQhy9woqL0wTceckfGF3nQRQ==",
       "dev": true,
       "requires": {
         "@comunica/types": "^1.21.1",
@@ -2015,9 +1988,9 @@
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.21.1.tgz",
-      "integrity": "sha512-9iLabwHs4s25WJxg+jOBvgNg/Lvopl1k015mikXN1qS9nhYje0obVR0rcDzMCu7NzhLAJO8c94oJK3FGp/91Yg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-xPqalmx2a84HzdZ87YVswJYf05Uj/AyRXmtQfHB2XNULzReNLyq56LUs22tOqWDuthzgL/0yTKtzYh8d8J4WVQ==",
       "dev": true,
       "requires": {
         "@comunica/types": "^1.21.1",
@@ -2074,9 +2047,9 @@
       }
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.21.1.tgz",
-      "integrity": "sha512-p1sHh8inTzY9PPiCTstBQUS5cq9POtm5J6uq4FkUyP1S4PH7BlRgs+fRGln9tSvKCz6JBckAjj4weg3AXMd7Tw==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.21.2.tgz",
+      "integrity": "sha512-O82jBCmkeSy8JMaKfZOqnn3QYHfj/0Z8CRSfYsGV83xjVuXv/hg0QogKmoW9Vl0wJRoVLb/ydpmVXaBFzH3rnw==",
       "dev": true,
       "requires": {
         "@comunica/types": "^1.21.1",
@@ -2100,9 +2073,9 @@
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.21.1.tgz",
-      "integrity": "sha512-4XmH1gjScaba9KOA7Js4CLWJTgUWs/RWjuydZ2nh/K/WpSf46lG1yDm3i+xhCrtUVoLqcOcnbfFnN8b/XQAQ+Q==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.21.2.tgz",
+      "integrity": "sha512-datwGMxBhAV6jDPENGmOJGkC9qTGCaOQijWrd0AbeYlThD3GaBeGl+n86xd3sfY3AwGQrkle2DwEhjliXPmtng==",
       "dev": true,
       "requires": {
         "@comunica/types": "^1.21.1",
@@ -2275,9 +2248,9 @@
       }
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.21.1.tgz",
-      "integrity": "sha512-gfaqNg4tNO+R1+NSO8/nRjFVZdGusmo5wvfd/gO9V6eFtWI7tr6FsN8LyxCH9Y5nyIbsCyX5HKL2qYg2PlImCA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.21.2.tgz",
+      "integrity": "sha512-Zyy1SgumHMQKziQFujgckXWG46Un1clGLgNObf1tTy4Gj66kWzO8YNZ5nuXVbFY6D1DyAis4vzsZvV1ieKX7gQ==",
       "dev": true,
       "requires": {
         "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
@@ -2286,7 +2259,7 @@
         "@types/rdf-js": "*",
         "arrayify-stream": "^1.0.0",
         "asynciterator": "^3.1.0",
-        "fetch-sparql-endpoint": "^1.7.0",
+        "fetch-sparql-endpoint": "^2.0.0",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^2.5.5"
@@ -2406,9 +2379,9 @@
       "dev": true
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.1.tgz",
-      "integrity": "sha512-BSBg8jrqSNflfNYbDMftWYV7qggNMUnysMb78Q2xJItSzUuAE5/1GoWMrooqrCeYMMICa4F+IJFltS4R7vXjUQ==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.21.2.tgz",
+      "integrity": "sha512-TLQLw6rKkcslHyyYFpELy+Oc9KuLZbqxiOpMUQQqfi1/yLT/8C0dvQSTl0dOtKombSn4N3aFsA0ycbjuPWi01w==",
       "dev": true,
       "requires": {
         "cross-fetch": "^3.0.5",
@@ -2479,9 +2452,9 @@
       "dev": true
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.21.1.tgz",
-      "integrity": "sha512-eob9bD4eHnzIO9uIdVXUqWh8ypeeh7a1KfOSRC5hLOznGZPCxyk9yBM0E4OuJna8GKN8v+TLRyZuHdBPOnAFGg==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.21.2.tgz",
+      "integrity": "sha512-3sO7giO4UroalkIHGU3KlFQk+OINOvUx3eCdD60nZUvxRBlfUKkSMyYmCbGEY0O9LWvVAXWclnwlKfI+C7mPdQ==",
       "dev": true,
       "requires": {
         "relative-to-absolute-iri": "^1.0.5"
@@ -2537,15 +2510,15 @@
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.1.tgz",
-      "integrity": "sha512-0pnZJUQ5bhaUwM7pQNr1afmoVKMmnYhJHdub9j/l2jAJWJFbVWucZI9z/g7r9Tek4SBS6PcM2+2sx8U9+WiiIA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.21.2.tgz",
+      "integrity": "sha512-YUiYo2EJ9T1oUGgBwzzPRjXT+cd/xckWbtfYBzr7RugXeKjrVai8atnV1OsPc0u5iPZCTkiVCO9sI/Q6M7ig2w==",
       "dev": true,
       "requires": {
         "@comunica/context-entries": "^1.21.1",
         "@types/rdf-js": "*",
         "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.3.0",
+        "jsonld-streaming-parser": "^2.3.2",
         "stream-to-string": "^1.2.0"
       }
     },
@@ -2615,17 +2588,17 @@
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.21.1.tgz",
-      "integrity": "sha512-7HmBu56POYZigcqcu20ZeCpYRLz70hgv+37CRTpR8ZT9CCorLS7Zd0bpoJUgHYy8/b7ivM+7/cZcizfg8ANkDw==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.21.2.tgz",
+      "integrity": "sha512-q6S9RDxzr00RViBrZ1wUHfzFjkXcHFWfRXbVI0bG2MR/oN9SVySLgSozte9KFjCWiuFc25jsntyB1dfXiH/i6Q==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.21.1",
         "@comunica/bus-query-operation": "^1.21.1",
         "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
         "@comunica/types": "^1.21.1",
         "@types/rdf-js": "*",
         "asynciterator": "^3.1.0",
+        "fetch-sparql-endpoint": "^2.0.0",
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^2.5.5"
@@ -2675,21 +2648,6 @@
       "requires": {
         "@types/rdf-js": "*",
         "asynciterator": "^3.1.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.21.1.tgz",
-      "integrity": "sha512-fmNzI2QKhK4rb2fB4eqkn7PataPaSZ0eIg2oyKFKB9lAVuva9+qgpCb0BppzALT0ZDYeqsnqenj+jHm/wSbo2w==",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.21.1",
-        "@types/rdf-js": "*",
-        "asynciterator": "^3.1.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^2.5.5",
-        "sparqljson-parse": "^1.6.0"
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
@@ -3221,15 +3179,15 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
@@ -3250,9 +3208,9 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -3264,13 +3222,32 @@
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
-        "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -3278,38 +3255,38 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
         }
       }
     },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
     },
@@ -3502,15 +3479,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/paper-ripple": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.2.tgz",
-      "integrity": "sha512-DnLNvYIMsiayeICroYxx6Q6Hg1cUU8HN2sbutXazlemAlGqdq80qz3TIaVdbpbt/pvjcFGX2HtntMlPstCge8Q==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/paper-spinner": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/paper-spinner/-/paper-spinner-3.0.2.tgz",
@@ -3558,6 +3526,15 @@
         "prismjs": "^1.11.0"
       }
     },
+    "@rdfjs/types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
+      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
@@ -3593,9 +3570,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.0.tgz",
-      "integrity": "sha512-hAEzXi6Wbvlb67NnGMGSNOeAflLVnMa4yliPU/ty1qjgW/vAletH15/v/esJwASSIA0YlIyjnloenFbEZc9q9A==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -3628,9 +3605,9 @@
       }
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -3638,9 +3615,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-      "integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
+      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
     },
     "@types/chai-dom": {
@@ -3653,9 +3630,9 @@
       }
     },
     "@types/co-body": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-5.1.0.tgz",
-      "integrity": "sha512-iRL97yYTJNGFv495U63ikKG9r60thDtQ403jEzBEFR4IY6kMxw2IfcPoxI8+HY3nRNLrwHFYuCnWGEB/0hFVwg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-5.1.1.tgz",
+      "integrity": "sha512-0/6AjTfQc5OJUchOS4OHiXNPZVuk+5XvEC2vdcizw/bwx0yb0xY7TKSf8JYvQYZ/OJDiAEjWzxnMjGPnSVlPmA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3663,36 +3640,36 @@
       }
     },
     "@types/command-line-args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.1.tgz",
+      "integrity": "sha512-+pAMlf+fHYWFDf4OvzEXPsVKLIahB66drrWXPxMe9IapFxjF5Ir+kFAR9qctKxZW4weuFL5ydm3V5yCGnJieew==",
       "dev": true
     },
     "@types/connect": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
-      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ==",
       "dev": true
     },
     "@types/convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha512-laiDIXqqthjJlyAMYAXOtN3N8+UlbM+KvZi4BaY5ZOekmVkBs/UxfK5O0HWeJVG2eW8F+Mu2ww13fTX+kY1FlQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-1.5.2.tgz",
+      "integrity": "sha512-tHs++ZeXer40kCF2JpE51Hg7t4HPa18B1b1Dzy96S0eCw8QKECNMYMfwa1edK/x8yCN0r4e6ewvLcc5CsVGkdg==",
       "dev": true
     },
     "@types/cookies": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",
-      "integrity": "sha512-FK4U5Qyn7/Sc5ih233OuHO0qAkOpEcD/eG6584yEiLKizTFRny86qHLe/rej3HFQrkBuUjF4whFliAdODbVN/w==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -3714,9 +3691,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
-      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -3726,9 +3703,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3743,15 +3720,15 @@
       "dev": true
     },
     "@types/http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
       "dev": true
     },
     "@types/http-link-header": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.2.tgz",
-      "integrity": "sha512-rWvCGMtwx+01LFVpLbSYagloSMgqDwfzLSx9JcwUEkJWo4oDBKihp6X92Ff5tIS4VE5ojV4wH6iMnAnr/TZhhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
+      "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3773,19 +3750,13 @@
       }
     },
     "@types/istanbul-reports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
     },
     "@types/keygrip": {
       "version": "1.0.2",
@@ -3794,9 +3765,9 @@
       "dev": true
     },
     "@types/koa": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.1.tgz",
-      "integrity": "sha512-Qbno7FWom9nNqu0yHZ6A0+RWt4mrYBhw3wpBAQ3+IuzGcLlfeYkzZrnMq5wsxulN2np8M4KKeUpTodsOsSad5Q==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
+      "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
@@ -3819,9 +3790,9 @@
       }
     },
     "@types/lru-cache": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true
     },
     "@types/mime": {
@@ -3831,9 +3802,9 @@
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "@types/mocha": {
@@ -3843,25 +3814,25 @@
       "dev": true
     },
     "@types/n3": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.8.0.tgz",
-      "integrity": "sha512-uyVeuz1TmdmKORidY0+hSfhonXgMk/hzpTnfZXG4HmQdXdykeoi7ohVxmAfYX21aaIcx9wJr1nqRN1griAOMPw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.10.2.tgz",
+      "integrity": "sha512-oLnYHDr191UYi+JfxxqmAFshXe/xZsAndKdD4v9mA9jeXc2VjG1b2T44aW+HsZZcweSjE5v7GR8mEU/bTQD7nw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "@types/rdf-js": "*"
+        "rdf-js": "^4.0.2"
       }
     },
     "@types/node": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
-      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==",
       "dev": true
     },
     "@types/normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -3886,24 +3857,24 @@
       }
     },
     "@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
     "@types/rdf-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.1.tgz",
-      "integrity": "sha512-S+28+3RoFI+3arls7dS813gYnhb2HiyLX+gs00rgIvCzHU93DaYajhx4tyT+XEO8SjtzZw90OF4OVdYXBwbvkQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "rdf-js": "*"
       }
     },
     "@types/resolve": {
@@ -3916,15 +3887,15 @@
       }
     },
     "@types/semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-4g1jrL98mdOIwSOUh6LTlB0Cs9I0dQPwINUhBg7C6pN4HLr8GS8xsksJxilW6S6dQHVi2K/o+lQuQcg7LroCnw==",
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
-      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "dev": true,
       "requires": {
         "@types/mime": "^1",
@@ -3932,12 +3903,12 @@
       }
     },
     "@types/sinon": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.0.tgz",
-      "integrity": "sha512-jDZ55oCKxqlDmoTBBbBBEx+N8ZraUVhggMZ9T5t+6/Dh8/4NiOjSUfpLrPiEwxQDlAe3wpAkoXhWvE6LibtsMQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
+      "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
       "dev": true,
       "requires": {
-        "@sinonjs/fake-timers": "^7.0.4"
+        "@sinonjs/fake-timers": "^7.1.0"
       }
     },
     "@types/sinon-chai": {
@@ -3957,12 +3928,12 @@
       "dev": true
     },
     "@types/sparqljs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.1.tgz",
-      "integrity": "sha512-S/+x6MDEBzVlLvBhsH/r6UvD3I0jXYpWiahCNkcmd8Dli6brxAiTorQ1ZKIGpPgP1tmZrmuQ075Fi7KIrrMXDA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.3.tgz",
+      "integrity": "sha512-nmFgmR6ns4i8sg9fYu+293H+PMLKmDOZy34sgwgAeUEEiIqSs4guj5aCZRt3gq1g0yuKXkqrxLDq/684g7pGtQ==",
       "dev": true,
       "requires": {
-        "@types/rdf-js": "*"
+        "rdf-js": "^4.0.2"
       }
     },
     "@types/uritemplate": {
@@ -3972,33 +3943,33 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
     },
     "@types/ws": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.4.tgz",
-      "integrity": "sha512-d/7W23JAXPodQNbOZNXvl2K+bqAQrCMwlh/nuQsPSQk6Fq0opHoPrUw43aHsvSbIiQPr8Of2hkFbnz1XBFVyZQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-ijZ1vzRawI7QoWnTNL8KpHixd2b2XVb9I9HAqI3triPsh1EC0xH0Eg6w2O3TKbDCgiNNlJqfrof6j4T2I+l9vw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/xml": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.5.tgz",
-      "integrity": "sha512-h3PVM7waRi2UeoaY2BhpLGvettU/3vfCbsjXMV/9Ex5WjvIy82J8Qfp1xiPxM4kTSOLdFFpjRwQ7YY7XJeKBvg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-BCpp2oke88DwxJ/h748oLOQWdZ6k1Uv+aB9LZpyh/VhWqe4mE7X7ysNhF57cRPBs8/GyuUn1VRl+IlFdYsZPsA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4006,9 +3977,9 @@
       }
     },
     "@web/browser-logs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.3.tgz",
-      "integrity": "sha512-Ylp/5S07j1P/mO2EsCBMGJ8piwh2RWh9h4G/b1gapQvq85XaphjMA2S/dug4DOHJ15OdhMqbgVJPQ5edLXnW4w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.4.tgz",
+      "integrity": "sha512-11DAAv8ZqbO267dwBLXtvmDoJXXucG5n+i9oQQEEVgbgXKOvK/7eqGhrSDKuZ7TTTkSci9fW7ZcuKFtaKskAIA==",
       "dev": true,
       "requires": {
         "errorstacks": "^2.2.0"
@@ -4024,9 +3995,9 @@
       }
     },
     "@web/dev-server": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.17.tgz",
-      "integrity": "sha512-2gdOjkQp97uaORkOL8X90f4retqZ2lA9YqHDljpf4SFg0JWoY8X7EJA9XQG1jJ2x46oQ5zqJX7AiSWc47B2k6A==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.18.tgz",
+      "integrity": "sha512-mMXI9IgowYmRXlKfvDCAPDvfjtuqpo74GmbDbd1ZF5IIHanvCF4d1xBPxc+w403bnbwj2cqjWc8wed+zp8JSoQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -4034,7 +4005,7 @@
         "@types/command-line-args": "^5.0.0",
         "@web/config-loader": "^0.1.3",
         "@web/dev-server-core": "^0.3.12",
-        "@web/dev-server-rollup": "^0.3.3",
+        "@web/dev-server-rollup": "^0.3.5",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -4089,9 +4060,9 @@
       }
     },
     "@web/dev-server-core": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.12.tgz",
-      "integrity": "sha512-PI7neqHvsgsE+GJnJNSjMGeWHSo8MgO99CAzVm6UtFeAjShmMGWp6WQTDJPzvsE4jnYhIg8EPwz2cqDIGnkU6A==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.13.tgz",
+      "integrity": "sha512-bGJHPeFRWATNfuL9Pp2LfqhnmqhBCc5eOO5AWQa0X+WQAwHiFo6xZNfsvsnJ1gvxXgsE4jKBAGu9lQRisvFRFA==",
       "dev": true,
       "requires": {
         "@types/koa": "^2.11.6",
@@ -4115,9 +4086,9 @@
       }
     },
     "@web/dev-server-rollup": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.4.tgz",
-      "integrity": "sha512-QFaqHpJXri1TuN1yN0N670bxF5noC1RtIHPhoM5Sp6YX7v3610Z/fq465V7fNaeHnTNN7dIUmNkK9vqLIrsYTg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.5.tgz",
+      "integrity": "sha512-eDLy3Da3qXqfPxOB7qZvR5NscXCZ63NyxoyPR0R/ukPs7ThvkAfwrtnKXckQo4vh5+FMytZXhyDcqPgeGDlGlg==",
       "dev": true,
       "requires": {
         "@web/dev-server-core": "^0.3.3",
@@ -4182,18 +4153,18 @@
       }
     },
     "@web/test-runner": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.13.4.tgz",
-      "integrity": "sha512-TuS8UnW+bdY0K2RoqldyORJime4R1cnARvUtxsXJDbHq78Dcfud2xCgrOepQbbxbniF77OShuEEwCXNULftobw==",
+      "version": "0.13.13",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.13.13.tgz",
+      "integrity": "sha512-S5THo5NZGJSzHbXTaqQi9y0h8xpVMRLiiVMYmNlwvqHJpn4GLwryXlU+BNUtM9mZGdW3BmIwsmD0OKGEpNj7uw==",
       "dev": true,
       "requires": {
         "@web/browser-logs": "^0.2.2",
         "@web/config-loader": "^0.1.3",
         "@web/dev-server": "^0.1.17",
         "@web/test-runner-chrome": "^0.10.0",
-        "@web/test-runner-commands": "^0.4.5",
-        "@web/test-runner-core": "^0.10.17",
-        "@web/test-runner-mocha": "^0.7.2",
+        "@web/test-runner-commands": "^0.5.5",
+        "@web/test-runner-core": "^0.10.18",
+        "@web/test-runner-mocha": "^0.7.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -4272,9 +4243,9 @@
       }
     },
     "@web/test-runner-commands": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.4.5.tgz",
-      "integrity": "sha512-jbhsS+nZmnbZPj/XL/g4se1c9TRtIgwrlYpaIIcWkHhCu5mKbdipgZ/nlFIhFS9UaVY52NiulmVj6dhAx7w4SA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.5.5.tgz",
+      "integrity": "sha512-tWHez95kqJbtcO79eIVtpJcznqGf4OMVo4fWdJhPVdp2GY81SeE2WAE7RLFgZuFxW33p/ycP7LmotELqU0JLIg==",
       "dev": true,
       "requires": {
         "@web/test-runner-core": "^0.10.14",
@@ -4290,9 +4261,9 @@
       }
     },
     "@web/test-runner-core": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.17.tgz",
-      "integrity": "sha512-T8yLQ6W4tHwREEYlAvAMYXpNkRE4XBynuWQQVq1qf5hf/IFNdYkOVELkgsHevtYLRElxi9/wHeRrn1SkDgj0Ug==",
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.18.tgz",
+      "integrity": "sha512-4emmE7tPMh5Wt/79tM1YYcBBnhBc4ecQxTtuyIIDeLPX8mtJoOx9OcP/V4baWDGOpNt6F4Ir6ELpOsconCISoA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -4384,9 +4355,9 @@
       }
     },
     "@web/test-runner-mocha": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.2.tgz",
-      "integrity": "sha512-UsaLvJ0k5Kb53WegF0J0pmKxCLdo6Nxl7GHYykO7m99Irz+jIGXV7VJP9/b8t+HH3fHyqB2Nmd5q9oxXwIJyNw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.3.tgz",
+      "integrity": "sha512-EbJydgh9Peo74SR0WjAEXs9X64ec41RaSXp4yXCup7jzvzH/5mQd2kZ/ga9F8Jh3zcKknR+s59JLVivgc5Ni7A==",
       "dev": true,
       "requires": {
         "@types/mocha": "^8.2.0",
@@ -4394,9 +4365,9 @@
       },
       "dependencies": {
         "@types/mocha": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-          "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+          "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
         }
       }
@@ -4475,9 +4446,9 @@
       "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "agent-base": {
@@ -4490,9 +4461,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -4534,9 +4505,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "amf-client-js": {
-      "version": "4.7.3-1",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.3-1.tgz",
-      "integrity": "sha512-g96aaHIhrAKAvZSOCPZUa6EAPRn1hVzIi1y9qkAOfAiiQSn7IQ6KoEmKu0u9i5JHWJx6lN0v5gBJYeFjAyh8rA==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.5.tgz",
+      "integrity": "sha512-ujScIhuxEUbqruwExGtHfEijKpAdH/+rV97JmvP3H8IqBDagYHbMe0cFlMBJpV78CTcIV3e4bbL6pbjofxZohg==",
       "dev": true,
       "requires": {
         "ajv": "6.5.2",
@@ -4744,9 +4715,9 @@
       "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
     },
     "axe-core": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz",
-      "integrity": "sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.1.tgz",
+      "integrity": "sha512-3WVgVPs/7OnKU3s+lqMtkv3wQlg3WxK1YifmpJSDO0E1aPBrZWlrrTO6cxRqCXLuX2aYgCljqXIQd0VnRidV0g==",
       "dev": true
     },
     "axobject-query": {
@@ -4979,19 +4950,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -5076,17 +5047,6 @@
         }
       }
     },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5139,9 +5099,9 @@
       }
     },
     "codemirror": {
-      "version": "5.61.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
-      "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
+      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
     },
     "color": {
       "version": "3.0.0",
@@ -5178,6 +5138,12 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -5195,12 +5161,12 @@
       }
     },
     "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.3.tgz",
+      "integrity": "sha512-a5tF6mjqRSOBswBwdMkKY47JQ464Dkg9Pcwbxwo9wxRhKWZjtBktmBASllk3AMJ7qBuWgsAGtVa7b2/+EsymOQ==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
@@ -5299,9 +5265,9 @@
       }
     },
     "componentsjs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.2.0.tgz",
-      "integrity": "sha512-8C+LXmz6SrkWPLJXFu622hAikNJZahxDuNnP2eJdMiPOtef/oWB0yf9+bOB4Dectu96MFq9nlsm0q+hmRGpN/g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.4.0.tgz",
+      "integrity": "sha512-lpceBsCYHG9QUuo+Hb0lAe7pAKi+E7JFr3qe5fbLhIcj92wu3kU822U4hYjE0u0JVYRDK6edEsoa6leEABWI2Q==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
@@ -5312,7 +5278,7 @@
         "minimist": "^1.2.0",
         "rdf-data-factory": "^1.0.4",
         "rdf-object": "^1.8.0",
-        "rdf-parse": "^1.8.0",
+        "rdf-parse": "^1.8.1",
         "rdf-quad": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "semver": "^7.3.2",
@@ -5320,9 +5286,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.0.tgz",
-          "integrity": "sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA==",
+          "version": "14.17.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
+          "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
           "dev": true
         }
       }
@@ -5435,9 +5401,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -5462,9 +5428,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.12.1.tgz",
-      "integrity": "sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
+      "integrity": "sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==",
       "dev": true
     },
     "core-util-is": {
@@ -5578,9 +5544,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
     "dedent": {
@@ -5657,12 +5623,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5773,14 +5733,14 @@
       }
     },
     "dompurify": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
-      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
+      "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
     },
     "domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
@@ -5908,9 +5868,9 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -5921,14 +5881,14 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-module-lexer": {
@@ -5977,13 +5937,14 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.1",
+        "@eslint/eslintrc": "^0.4.2",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -6000,7 +5961,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
+        "glob-parent": "^5.1.2",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
@@ -6079,9 +6040,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -6180,9 +6141,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
-      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
@@ -6317,9 +6278,9 @@
       }
     },
     "eslint-plugin-lit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.4.1.tgz",
-      "integrity": "sha512-7UIbjSa1DGH7ZaDhmGZPHWm17kOjCrGP4VAKNjR0wZVdQLuRKXE+LqXysQ1L3O12hBnExkMG2J9swXpQvuCuXA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lit/-/eslint-plugin-lit-1.5.1.tgz",
+      "integrity": "sha512-pYB0QM11uyOk5L55QfGhBmWi8a56PkNsnx+zVpY4bxz9YVquEo4BeRnFmf9AwFyT89rhGud9QruFhM2xJ4piwg==",
       "dev": true,
       "requires": {
         "parse5": "^6.0.1",
@@ -6520,9 +6481,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.3",
@@ -6549,9 +6510,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -6599,17 +6560,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
@@ -6625,15 +6585,15 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==",
       "dev": true
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6663,11 +6623,14 @@
       }
     },
     "fetch-sparql-endpoint": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.9.0.tgz",
-      "integrity": "sha512-iACwPeKhvy5aM2rbzdnKOUWHLM3tW+odZ88pdPG+xCXSTGMtWBI8FP8fqgHcZsxNq9NfRU7+pMsMsU5JCNabCA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-2.1.1.tgz",
+      "integrity": "sha512-uOTQa9EUoZ1D1lPUOe7ILrT3imDSLNUNPZiQW/Rp59mbm8UHktf5Ch2l/P3hCEOt333OdEZEawFUwyF3EIebwQ==",
       "dev": true,
       "requires": {
+        "@types/rdf-js": "*",
+        "@types/sparqljs": "^3.0.1",
+        "abort-controller": "^3.0.0",
         "cross-fetch": "^3.0.6",
         "is-stream": "^2.0.0",
         "minimist": "^1.2.0",
@@ -6678,15 +6641,6 @@
         "sparqlxml-parse": "^1.4.0",
         "stream-to-string": "^1.1.0",
         "web-streams-node": "^0.4.0"
-      }
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -6754,9 +6708,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
     },
     "fn.name": {
@@ -6789,12 +6743,11 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -6955,9 +6908,9 @@
       }
     },
     "globals": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -6972,9 +6925,9 @@
       }
     },
     "globby": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -6993,24 +6946,15 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
       "dev": true
     },
     "graphql-ld": {
@@ -7261,9 +7205,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -7455,9 +7399,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -7806,12 +7750,12 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.5"
       }
     },
     "jsonc-parser": {
@@ -7866,9 +7810,9 @@
       }
     },
     "jsonld-streaming-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.3.0.tgz",
-      "integrity": "sha512-IJiFhX9GQ/uLugd3BSYgJDaisAc22fV2Ij7tH0yWG8KZpriSGadRVvxUkfglzRKSjqxYBsZ+qAQ+UR7YGwiHRQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.3.2.tgz",
+      "integrity": "sha512-C9hyL5LRb2K0eaS5biP+ixUtMjr3UPJn9WInNYAmjX9tL7NzeSw3lY7nW3GEnKETxF3I3btvEPR1Nm/+tHMWZQ==",
       "dev": true,
       "requires": {
         "@types/http-link-header": "^1.0.1",
@@ -7906,9 +7850,9 @@
       "dev": true
     },
     "jsrsasign": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.2.0.tgz",
-      "integrity": "sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg=="
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.3.0.tgz",
+      "integrity": "sha512-irDIKKFW++EAELgP3fjFi5/Fn0XEyfuQTTgpbeFwCGkV6tRIYZl3uraRea2HTXWCstcSZuDaCbdAhU1n+075Bg=="
     },
     "jstransform": {
       "version": "11.0.3",
@@ -8040,9 +7984,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -8255,9 +8199,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.0.0.tgz",
-      "integrity": "sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.0.1.tgz",
+      "integrity": "sha512-RkTA1ulE6jAGFskxpGAwxfVRXjHp7D9gFg/+KMARUWMPiVFP0t28Em2u0gL8sA0w3/ck3TC57F2v2RNeQ5XPnw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.1",
@@ -8318,9 +8262,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -8345,56 +8289,18 @@
       }
     },
     "listr2": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.8.2.tgz",
-      "integrity": "sha512-E28Fw7Zd3HQlCJKzb9a8C8M0HtFWQeucE+S8YrSrqZObuCLPRHMRrR8gNmYt65cU9orXYHwvN5agXC36lYt7VQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
+      "integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.1",
         "cli-truncate": "^2.1.0",
-        "figures": "^3.2.0",
-        "indent-string": "^4.0.0",
+        "colorette": "^1.2.2",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rxjs": "^6.6.7",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
       }
     },
     "lit-element": {
@@ -8804,18 +8710,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.48.0"
       }
     },
     "mimic-fn": {
@@ -9189,9 +9095,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.10.0.tgz",
-      "integrity": "sha512-y+qpS0GktEBttOaDR+BF1t1G2fw4Xn4nCZWNn+7MvEmD2I4YpMH6OJF/xHKSwInCxOC9vu9eI6pluB9/RDUyZQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.11.0.tgz",
+      "integrity": "sha512-hdGhm7BbiesuQTm2S4Gsq2Z0J/iCRMsvtmrlLNxzXlnf1aSRsbKQk5XkFNKtX9aS54oKzyGSZUVm7F/IOhmFhg==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
@@ -9382,9 +9288,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
       "dev": true
     },
     "object-keys": {
@@ -9405,15 +9311,14 @@
       }
     },
     "object.entries": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "object.getownpropertydescriptors": {
@@ -9428,15 +9333,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "on-finished": {
@@ -9481,9 +9385,9 @@
       "dev": true
     },
     "open": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.1.0.tgz",
-      "integrity": "sha512-jB5hAtsDOhCy/FNQJwQJOrGlxLUat482Yr14rbA5l2Zb1eOeoS+ccQPO036C1+z9VDBTmOZqzh1tBbI4myzIYw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+      "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
@@ -9618,9 +9522,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -9798,9 +9702,9 @@
       }
     },
     "playwright": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.11.1.tgz",
-      "integrity": "sha512-UuMrYuvzttbJXUD7sTVcQBsGRojelGepvuQPD+QtVm/n5zyKvkiUErU/DGRXfX8VDZRdQ5D6qVqZndrydC2b4w==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.12.3.tgz",
+      "integrity": "sha512-eyhHvZV7dMAUltqjQsgJ9CjZM8dznzN1+rcfCI6W6lfQ7IlPvTFGLuKOCcI4ETbjfbxqaS5FKIkb1WDDzq2Nww==",
       "dev": true,
       "requires": {
         "commander": "^6.1.0",
@@ -9815,7 +9719,7 @@
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1",
+        "ws": "^7.4.6",
         "yazl": "^2.5.1"
       },
       "dependencies": {
@@ -9826,9 +9730,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -10118,12 +10022,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
     },
     "private": {
       "version": "0.1.8",
@@ -10220,9 +10121,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -10336,6 +10237,15 @@
         "rdf-terms": "^1.6.2"
       }
     },
+    "rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dev": true,
+      "requires": {
+        "@rdfjs/types": "*"
+      }
+    },
     "rdf-literal": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.2.0.tgz",
@@ -10359,9 +10269,9 @@
       }
     },
     "rdf-parse": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.8.0.tgz",
-      "integrity": "sha512-Pc6jvqjlJpY/ivVPbfbCJw372VhUx1dTMGLGGU/bHz6srjLL9Q4scn655afAuDI89KamDBRTDN+ZzlfiWfgbfg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.8.1.tgz",
+      "integrity": "sha512-sNcQ1Vc8hDf/hVjVHYS9CSHyFShVX8LVwBrFARKkGgGe+K9DZJRaZQI06VCwmEW027ZFjfxFgmjQlc09FLmI4A==",
       "dev": true,
       "requires": {
         "@comunica/actor-http-native": "~1.21.1",
@@ -10369,7 +10279,7 @@
         "@comunica/actor-rdf-parse-html-microdata": "~1.21.1",
         "@comunica/actor-rdf-parse-html-rdfa": "~1.21.1",
         "@comunica/actor-rdf-parse-html-script": "~1.21.1",
-        "@comunica/actor-rdf-parse-jsonld": "~1.21.1",
+        "@comunica/actor-rdf-parse-jsonld": "~1.21.2",
         "@comunica/actor-rdf-parse-n3": "~1.21.1",
         "@comunica/actor-rdf-parse-rdfxml": "~1.21.1",
         "@comunica/actor-rdf-parse-xml-rdfa": "~1.21.1",
@@ -10562,9 +10472,9 @@
       "dev": true
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -10616,9 +10526,9 @@
       "dev": true
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "relative-to-absolute-iri": {
@@ -10801,12 +10711,12 @@
       }
     },
     "rollup": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.49.0.tgz",
-      "integrity": "sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
+      "integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {
@@ -10857,12 +10767,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/scope-eval/-/scope-eval-0.0.3.tgz",
       "integrity": "sha1-Fm8szR83VEKd7FEYBVAfnWkjtew="
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "semver": {
       "version": "7.3.5",
@@ -10964,9 +10868,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
-      "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true
     },
     "slash": {
@@ -11393,9 +11297,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+          "version": "8.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+          "integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -11537,12 +11441,6 @@
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
       }
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
     },
     "to-boolean-x": {
       "version": "1.0.3",
@@ -11686,9 +11584,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
     "trim-off-newlines": {
@@ -11723,13 +11621,12 @@
       "dev": true
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
       "dev": true,
       "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       }
@@ -11778,9 +11675,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "typescript-lit-html-plugin": {
@@ -11820,9 +11717,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
-      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "dev": true
     },
     "unbox-primitive": {
@@ -12269,13 +12166,13 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "requires": {
         "lodash": "^4.7.0",
-        "tr46": "^2.0.2",
+        "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       }
     },
@@ -12544,9 +12441,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
       "dev": true
     },
     "xml": {
@@ -12594,9 +12491,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.7",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yargs-unparser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-documentation",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -733,9 +733,12 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.3.9.tgz",
-      "integrity": "sha512-IC2rQO+qRUs5T4r7QecV4RFKaphupiH22mLfGk+7UNFl2bYSFfFwiof7BHQXVkZRxEh0/pUlAI94APwk2+MJtg=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.4.0.tgz",
+      "integrity": "sha512-XHFM7oKrDjF4xwikhl2MPE0qo8P2SC9/ByfUz52wPAKGvM2gdVwJ/VrkpK2iQ0HLojwRaqM4ejy+0AMeeRJOXA==",
+      "requires": {
+        "amf-json-ld-lib": "0.0.13"
+      }
     },
     "@api-components/api-annotation-document": {
       "version": "4.2.0",
@@ -912,9 +915,9 @@
       }
     },
     "@api-components/api-method-documentation": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.2.3.tgz",
-      "integrity": "sha512-j1saTAacr1ltg2PXQhYU08stYL0XzDJ1ghDlV+rKhdPtqVNo/k4LFh0W2Pu0Y3T2jOZcBpz/hHSQcRbYuXkxbQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@api-components/api-method-documentation/-/api-method-documentation-5.2.4.tgz",
+      "integrity": "sha512-BJjOnQLfB9A9TYsAYfw53EmehT8rTtJoTbyK7AcSV7tp7fv9JIwczknG6fRTHkGaVSKYgaO/8pC5TFUdwy/Mjg==",
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.3.2",
         "@advanced-rest-client/arc-marked": "^1.1.1",
@@ -1118,30 +1121,37 @@
       }
     },
     "@api-components/api-summary": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-summary/-/api-summary-4.6.0.tgz",
-      "integrity": "sha512-38+wWMgfff4d6N08IjDqjsJ1e3knEnJqbLn9whi23jURXnavfusSxvwxzRW/o6YJiN8c5KfC3VGlpla1yCrvUw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-summary/-/api-summary-4.6.1.tgz",
+      "integrity": "sha512-KdzMwJU5LuOyj3/h4EfoXwugRTKRlm+dpSkuLmfwVyUnyBImWbWiNPLkNmwBMyfMI0MVRc1JEprbaDimGX/MAA==",
       "requires": {
         "@advanced-rest-client/arc-marked": "^1.1.1",
-        "@advanced-rest-client/markdown-styles": "^3.1.4",
-        "@api-components/amf-helper-mixin": "^4.3.6",
-        "@api-components/api-method-documentation": "^5.1.10",
+        "@advanced-rest-client/markdown-styles": "^3.1.5",
+        "@api-components/amf-helper-mixin": "^4.3.10",
+        "@api-components/api-method-documentation": "^5.2.3",
         "@api-components/http-method-label": "^3.1.4",
         "@api-components/raml-aware": "^3.0.0",
-        "dompurify": "^2.2.7",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.3.0"
+        "dompurify": "^2.2.9",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1"
+      },
+      "dependencies": {
+        "dompurify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
+          "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
+        }
       }
     },
     "@api-components/api-type-document": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.10.tgz",
-      "integrity": "sha512-1wEimN4IA4ImdDeApa86dtDyaeAvUGLKXA/kY46wSQr6I0v/ekMEaiNB/CLp35KgLX6TGIVrjgxyskyjjARbNA==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@api-components/api-type-document/-/api-type-document-4.2.13.tgz",
+      "integrity": "sha512-EWtzNA26TS+04JES+N2Eup3nYrZ1KVcFgBIVhq76BekEuALynI31hJRXSzsZmAfyxtbnnmzuUPuqxMonBYfkJA==",
       "requires": {
         "@advanced-rest-client/arc-marked": "^1.1.0",
         "@advanced-rest-client/markdown-styles": "^3.1.4",
         "@anypoint-web-components/anypoint-button": "^1.2.0",
-        "@api-components/amf-helper-mixin": "^4.3.6",
+        "@api-components/amf-helper-mixin": "^4.4.0",
         "@api-components/api-annotation-document": "^4.1.0",
         "@api-components/api-resource-example-document": "^4.1.2",
         "@open-wc/dedupe-mixin": "^1.3.0",
@@ -1149,18 +1159,36 @@
       }
     },
     "@api-components/api-type-documentation": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-type-documentation/-/api-type-documentation-4.1.2.tgz",
-      "integrity": "sha512-Piah06S4aV6Iqz4awUyjf6P8EscX/EMqq4vMl6OxN/MNo32wuJP7JJsS3aigMBm4Z6SdjiWOid/ay5cYB7MYQg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-type-documentation/-/api-type-documentation-4.2.1.tgz",
+      "integrity": "sha512-jQAaru9Asrl/bc+XCvg0q2MfB3UsovPldHVU+ZKdO0iwHuimx++qrXijsJ5DWrWgK/MYi2uGHuD9wDz8dejw7Q==",
       "requires": {
-        "@advanced-rest-client/arc-marked": "^1.1.0",
-        "@advanced-rest-client/markdown-styles": "^3.1.4",
-        "@api-components/amf-helper-mixin": "^4.3.6",
-        "@api-components/api-annotation-document": "^4.1.0",
-        "@api-components/api-resource-example-document": "^4.1.2",
-        "@api-components/api-schema-document": "^4.2.0",
-        "@api-components/api-type-document": "^4.2.4",
-        "lit-element": "^2.4.0"
+        "@advanced-rest-client/arc-marked": "^1.1.2",
+        "@advanced-rest-client/markdown-styles": "^3.1.5",
+        "@api-components/amf-helper-mixin": "^4.4.0",
+        "@api-components/api-annotation-document": "^4.2.0",
+        "@api-components/api-resource-example-document": "^4.3.2",
+        "@api-components/api-schema-document": "^4.3.0",
+        "@api-components/api-type-document": "^4.2.13",
+        "lit-element": "^2.5.1"
+      },
+      "dependencies": {
+        "@advanced-rest-client/arc-marked": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-marked/-/arc-marked-1.1.2.tgz",
+          "integrity": "sha512-YHi4aGGh8XFjLi4N0szqOBmtGiC6wn+UCB5josEhAP/oVwlRnWxSCNenwjvpINO+RJ8Dr09Ed5dVMGS/wz4yCw==",
+          "requires": {
+            "dompurify": "^2.2.9",
+            "lit-element": "^2.5.1",
+            "lit-html": "^1.4.1",
+            "marked": "^0.7.0"
+          }
+        },
+        "dompurify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.0.tgz",
+          "integrity": "sha512-VV5C6Kr53YVHGOBKO/F86OYX6/iLTw2yVSI721gKetxpHCK/V5TaLEf9ODjRgl1KLSWRMY6cUhAbv/c+IUnwQw=="
+        }
       }
     },
     "@api-components/api-url": {
@@ -4514,6 +4542,11 @@
         "ajv": "6.5.2",
         "amf-shacl-node": "2.0.0"
       }
+    },
+    "amf-json-ld-lib": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/amf-json-ld-lib/-/amf-json-ld-lib-0.0.13.tgz",
+      "integrity": "sha512-jv+jCh8kUb1+Ln9tKx7HvxlktxicBe2Pvxxmvoh/BN1ESFQnY3Xsm0X2I6CqcaVPdoDlyyRj7JM58YFXti+7vQ=="
     },
     "amf-shacl-node": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-documentation",
   "description": "A main documentation view for AMF model",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiDocumentationElement.js
+++ b/src/ApiDocumentationElement.js
@@ -1074,7 +1074,7 @@ export class ApiDocumentationElement extends EventsTargetMixin(AmfHelperMixin(Li
     const key = this._getAmfKey(this.ns.aml.vocabularies.apiContract.accepts);
     const value = this._ensureArray(webApi[key]);
     if (value) {
-      return value.map((item) => item['@value']);
+      return value.map((item) => typeof item === 'string' ? item : item['@value']);
     }
     return undefined;
   }

--- a/test/api-documentation.test.js
+++ b/test/api-documentation.test.js
@@ -1038,4 +1038,64 @@ describe('ApiDocumentationElement', () => {
       });
     });
   });
+
+  describe('_computeApiMediaTypes()', () => {
+    it('should return undefined if no encodes', async () => {
+      const element = await basicFixture();
+
+      const model = {};
+
+      const actual = element._computeApiMediaTypes(model);
+      assert.deepEqual(actual, undefined);
+    });
+
+    it('should return undefined if no media types present', async () => {
+      const element = await basicFixture();
+
+      const encodesKey = element._getAmfKey(element.ns.aml.vocabularies.document.encodes);
+
+      const encodes = { '@type': [element._getAmfKey(element.ns.schema.webApi)] };
+
+      const model = { [encodesKey]: encodes };
+
+      const actual = element._computeApiMediaTypes(model);
+      assert.deepEqual(actual, undefined);
+    });
+
+    it('should return values when they are contained in "@value" property', async () => {
+      const expected = ['application/json', 'application/xml'];
+      const element = await basicFixture();
+
+      const encodesKey = element._getAmfKey(element.ns.aml.vocabularies.document.encodes);
+      const acceptsKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.accepts);
+
+      const encodes = {
+        '@type': [element._getAmfKey(element.ns.schema.webApi)],
+        [acceptsKey]: [{ '@value': 'application/json' }, { '@value': 'application/xml' }]
+      };
+
+      const model = { [encodesKey]: encodes };
+
+      const actual = element._computeApiMediaTypes(model);
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should return values when they are not contained in "@value" property', async () => {
+      const expected = ['application/json', 'application/xml'];
+      const element = await basicFixture();
+
+      const encodesKey = element._getAmfKey(element.ns.aml.vocabularies.document.encodes);
+      const acceptsKey = element._getAmfKey(element.ns.aml.vocabularies.apiContract.accepts);
+
+      const encodes = {
+        '@type': [element._getAmfKey(element.ns.schema.webApi)],
+        [acceptsKey]: ['application/json', 'application/xml']
+      };
+
+      const model = { [encodesKey]: encodes };
+
+      const actual = element._computeApiMediaTypes(model);
+      assert.deepEqual(actual, expected);
+    });
+  });
 });


### PR DESCRIPTION
Sometimes the media types arrive as an array of strings rather than an array of objects. In this case, we should check if the iterated item is a string first, and only if it is not, then we should try and obtain the `@value` property from the iterated item.