### PR TITLE
@W-23748894 feat(webhooks): suppress Try-It per-operation for OAS 3.1/3.2 webhooks

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -18,5 +18,6 @@
   "multi-server/multi-server.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "async-api/async-api.yaml": "ASYNC 2.0",
   "APIC-711/APIC-711.raml": "RAML 1.0",
-  "W-12276810/W-12276810.raml": "RAML 1.0"
+  "W-12276810/W-12276810.raml": "RAML 1.0",
+  "oas31-webhooks/oas31-webhooks.yaml": { "type": "OAS 3.1", "mime": "application/yaml" }
 }

--- a/demo/oas31-webhooks/oas31-webhooks.yaml
+++ b/demo/oas31-webhooks/oas31-webhooks.yaml
@@ -1,0 +1,106 @@
+openapi: 3.1.0
+info:
+  title: Webhooks + Schema Composition Spike
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+
+# Top-level `webhooks` map of Path Item Objects, confirmed in OAS 3.1.0 spec
+# (versions/3.1.0.md, field `webhooks`, sibling to `paths`/`components`).
+webhooks:
+  newPet:
+    post:
+      operationId: newPetWebhook
+      summary: Notify subscriber of a newly created pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Webhook received successfully
+
+components:
+  schemas:
+    Pet:
+      # allOf: base fields + discriminated extra fields
+      allOf:
+        - $ref: "#/components/schemas/PetBase"
+        - $ref: "#/components/schemas/PetKindFields"
+
+    PetBase:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        kind:
+          type: string
+          enum: [dog, cat]
+
+    # if/then/else conditional (JSON Schema 2020-12, dialect used by OAS 3.1)
+    PetKindFields:
+      if:
+        properties:
+          kind:
+            const: dog
+      then:
+        properties:
+          breed:
+            type: string
+        required: [breed]
+      else:
+        properties:
+          indoor:
+            type: boolean
+        required: [indoor]
+
+    # oneOf: mutually exclusive contact methods
+    ContactMethod:
+      oneOf:
+        - $ref: "#/components/schemas/EmailContact"
+        - $ref: "#/components/schemas/PhoneContact"
+
+    EmailContact:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+
+    PhoneContact:
+      type: object
+      required: [phone]
+      properties:
+        phone:
+          type: string
+
+    # anyOf: owner may have one or more identifiers present
+    OwnerIdentifiers:
+      anyOf:
+        - required: [ownerId]
+          properties:
+            ownerId:
+              type: integer
+        - required: [ownerEmail]
+          properties:
+            ownerEmail:
+              type: string
+              format: email

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/events-target-mixin": "^3.2.4",
-        "@api-components/amf-helper-mixin": "^4.5.1",
+        "@api-components/amf-helper-mixin": "^4.5.38",
         "@api-components/api-documentation-document": "^4.1.0",
         "@api-components/api-endpoint-documentation": "^6.1.3",
         "@api-components/api-method-documentation": "^5.2.30",
@@ -27,7 +27,7 @@
         "@anypoint-web-components/anypoint-checkbox": "^1.2.2",
         "@anypoint-web-components/anypoint-input": "^0.2.27",
         "@anypoint-web-components/anypoint-styles": "^1.0.2",
-        "@api-components/api-model-generator": "^0.2.14",
+        "@api-components/api-model-generator": "^0.4.0",
         "@api-components/api-navigation": "^4.3.20",
         "@api-components/api-request": "^0.2.1",
         "@commitlint/cli": "^13.2.1",
@@ -652,6 +652,13 @@
       "version": "3.1.2",
       "license": "Apache-2.0"
     },
+    "node_modules/@aml-org/amf-antlr-parsers": {
+      "version": "0.9.154",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.9.154.tgz",
+      "integrity": "sha512-eXptBQVW/EuCiRAXl1qtOeMBQS9fFJKqMOH9b/PdvSAnIIFmrg/itqKsUdpnFRxFd0o9NYthbM/8Vc8sViBFQw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -891,9 +898,9 @@
       }
     },
     "node_modules/@api-components/amf-helper-mixin": {
-      "version": "4.5.34",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.34.tgz",
-      "integrity": "sha512-zw3169JqvFI4FpJY2ne9mfI0Z70rs4xpxve/cxPHsVQLbBJyAtjsGt/3xMm52ci5uVHtzdQ5yVTSrlHUDtA0LA==",
+      "version": "4.5.38",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.38.tgz",
+      "integrity": "sha512-v1sWZ9MevGOllbVtHC19IZ1BlkHlSq4FUerAyoquc3pKLMGYg5h0HyGYsgYKDyi+HSAYJUcpPGAq7YqZC/2ZYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "amf-json-ld-lib": "0.0.14"
@@ -1134,11 +1141,13 @@
       }
     },
     "node_modules/@api-components/api-model-generator": {
-      "version": "0.2.14",
+      "version": "0.4.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@api-components/api-model-generator/-/api-model-generator-0.4.0.tgz",
+      "integrity": "sha512-r/XlbF+A0DmxbqhmqSs+gX4T0n7RxLoag9hqIBo8a+kPZ99xO0NDXTFosqCZD4qD10tt2QDfWeU8BPgWOadOOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "amf-client-js": "^4.7.6",
+        "amf-client-js": "5.11.12531",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -1915,14 +1924,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-13.2.1.tgz",
@@ -2398,2049 +2399,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@comunica/actor-abstract-bindings-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "canonicalize": "^1.0.1",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-abstract-path": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-context-preprocess": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-http-memento": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-native": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "follow-redirects": "^1.5.1",
-        "parse-link-header": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-node-fetch": {
-      "version": "1.22.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-http-proxy": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.8.0",
-        "@comunica/context-entries": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-init-sparql": {
-      "version": "1.22.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-context-preprocess-source-to-destination": "^1.22.0",
-        "@comunica/actor-http-memento": "^1.22.1",
-        "@comunica/actor-http-native": "^1.22.1",
-        "@comunica/actor-http-node-fetch": "^1.22.3",
-        "@comunica/actor-http-proxy": "^1.22.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.22.0",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-group": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-minus": "^1.22.0",
-        "@comunica/actor-query-operation-nop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-reduced-hash": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.22.2",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-update-add-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-clear": "^1.22.0",
-        "@comunica/actor-query-operation-update-compositeupdate": "^1.22.0",
-        "@comunica/actor-query-operation-update-copy-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-create": "^1.22.0",
-        "@comunica/actor-query-operation-update-deleteinsert": "^1.22.2",
-        "@comunica/actor-query-operation-update-drop": "^1.22.0",
-        "@comunica/actor-query-operation-update-load": "^1.22.0",
-        "@comunica/actor-query-operation-update-move-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-dereference-fallback": "^1.22.2",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.22.3",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.22.0",
-        "@comunica/actor-rdf-metadata-all": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-metadata-extract-put-accepted": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.22.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.22.0",
-        "@comunica/actor-rdf-parse-html": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "^1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.1",
-        "@comunica/actor-rdf-parse-n3": "^1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.22.2",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.22.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-sparql": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.22.2",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-parse-graphql": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/actor-sparql-serialize-stats": "^1.22.1",
-        "@comunica/actor-sparql-serialize-table": "^1.22.0",
-        "@comunica/actor-sparql-serialize-tree": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/bus-http-invalidate": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-optimize-query-operation": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-dereference-paged": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-parse": "^1.22.0",
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/logger-pretty": "^1.22.0",
-        "@comunica/logger-void": "^1.22.0",
-        "@comunica/mediator-all": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.2",
-        "asynciterator": "^3.2.0",
-        "negotiate": "^1.0.1",
-        "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0",
-        "streamify-string": "^1.0.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "comunica-dynamic-sparql": "bin/query-dynamic.js",
-        "comunica-sparql": "bin/query.js",
-        "comunica-sparql-http": "bin/http.js"
-      }
-    },
-    "node_modules/@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.22.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-init-sparql": "^1.22.3",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0"
-      }
-    },
-    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-optimize-query-operation": "^1.0.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-ask": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-bgp-single": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-construct": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-describe-subject": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-extend": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-group": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.6.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-join": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.9.3",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-minus": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-nop": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-project": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-quadpattern": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-bindings-hash": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-service": {
-      "version": "1.22.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-slice": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-union": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-query-operation-values": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-query-operation": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-fallback": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-dereference": "^1.19.2",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.22.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/mediatortype-iterations": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.9.2",
-        "@comunica/core": "^1.9.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-join": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-all": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.6.3",
-        "@comunica/core": "^1.6.3"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/uritemplate": "^0.3.4",
-        "uritemplate": "0.3.4"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "htmlparser2": "^7.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microdata-rdf-streaming-parser": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.17.0",
-        "@comunica/core": "^1.17.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.4.0",
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.4.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdfxml-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.1.0",
-        "@comunica/core": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdfa-streaming-parser": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-parse": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.19.2",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-store-stream": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-rdf-metadata": "^1.0.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.8.0",
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "@types/lru-cache": "^5.1.0",
-        "asynciterator": "^3.2.0",
-        "lru-cache": "^6.0.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/bus-http-invalidate": "^1.0.0",
-        "@comunica/bus-rdf-dereference": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.0.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.0.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.2.0",
-        "@comunica/core": "^1.2.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonld-streaming-serializer": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.0.0",
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-serialize-n3": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.0.0",
-        "@comunica/core": "^1.0.0",
-        "@comunica/types": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.0.0",
-        "@comunica/core": "^1.0.0",
-        "@comunica/types": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string-ttl": "^1.1.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.0.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.21.1",
-        "@comunica/core": "^1.21.1"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http-invalidate": "^1.20.0",
-        "@comunica/bus-rdf-update-quads": "^1.20.0",
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.0.0",
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-algebra": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqljs": "^3.4.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-parse-graphql": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graphql-to-sparql": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-parse": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-json": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.5.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-rdf-serialize": "^1.0.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-simple": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string-ttl": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.15.0",
-        "@comunica/core": "^1.15.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/xml": "^1.0.2",
-        "xml": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-stats": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/bus-http": "^1.10.0",
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-table": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.6.2"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/actor-sparql-serialize-tree": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqljson-to-tree": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/bus-sparql-serialize": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-context-preprocess": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-http": {
-      "version": "1.22.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-http-invalidate": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-init": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/bus-query-operation": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-dereference-paged": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-join": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "graphql-ld": "^1.4.0",
-        "rdf-store-stream": "^1.3.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-init-sparql": "^1.16.2",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.8.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-serialize": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.20.0"
-      }
-    },
-    "node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "stream-to-string": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.19.2"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-parse": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sparqlalgebrajs": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/bus-sparql-serialize": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/context-entries": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@comunica/core": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "immutable": "^3.8.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/data-factory": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@comunica/logger-pretty": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/logger-void": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-all": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.4.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-combine-union": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-number": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediator-race": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/mediatortype-iterations": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/runner": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "componentsjs": "^4.0.6"
-      },
-      "bin": {
-        "comunica-compile-config": "bin/compile-config"
-      },
-      "peerDependencies": {
-        "@comunica/bus-init": "^1.0.0",
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@comunica/runner-cli": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/runner": "^1.22.0"
-      },
-      "bin": {
-        "comunica-run": "bin/run.js"
-      }
-    },
-    "node_modules/@comunica/types": {
-      "version": "1.22.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "sparqlalgebrajs": "^3.0.1"
-      }
-    },
-    "node_modules/@comunica/utils-datasource": {
-      "version": "1.22.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/context-entries": "^1.22.0",
-        "asynciterator": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@comunica/core": "^1.0.0"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
     },
     "node_modules/@emmetio/extract-abbreviation": {
       "version": "0.1.6",
@@ -5279,14 +3237,6 @@
         "prismjs": "^1.11.0"
       }
     },
-    "node_modules/@rdfjs/types": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.3.0",
       "dev": true,
@@ -5481,14 +3431,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-link-header": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
@@ -5543,11 +3485,6 @@
         "@types/koa": "*"
       }
     },
-    "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "dev": true,
@@ -5563,15 +3500,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/n3": {
-      "version": "1.10.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "rdf-js": "^4.0.2"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.1.2",
       "dev": true,
@@ -5586,11 +3514,6 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/parse-link-header": {
-      "version": "1.0.1",
       "dev": true,
       "license": "MIT"
     },
@@ -5612,20 +3535,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "dev": true,
@@ -5633,11 +3542,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -5679,34 +3583,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/spark-md5": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/sparqljs": {
-      "version": "3.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uritemplate": {
-      "version": "0.3.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "7.4.7",
       "dev": true,
@@ -5714,27 +3590,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/xml": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -6482,6 +4337,48 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/amdefine": {
       "version": "1.0.1",
       "license": "BSD-3-Clause OR MIT",
@@ -6490,16 +4387,44 @@
       }
     },
     "node_modules/amf-client-js": {
-      "version": "4.7.8",
+      "version": "5.11.12531",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/amf-client-js/-/amf-client-js-5.11.12531.tgz",
+      "integrity": "sha512-zAc/PwsOfsNzgii7LAsuJrYx+qXUBlOkd3Mwz3YD9r+jZjpJkEeDmxtb+N4F+Z5dy/g3i6J0kMfgeVYWCUOwtA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "6.12.6",
-        "amf-shacl-node": "2.0.0"
+        "@aml-org/amf-antlr-parsers": "0.9.154",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
+        "avro-js": "1.11.5"
       },
       "bin": {
         "amf": "bin/amf"
       }
+    },
+    "node_modules/amf-client-js/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/amf-client-js/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/amf-json-ld-lib": {
       "version": "0.0.14",
@@ -6507,17 +4432,6 @@
       "engines": {
         "node": ">=12.16.0",
         "npm": ">=6.13.4"
-      }
-    },
-    "node_modules/amf-shacl-node": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@comunica/actor-init-sparql-rdfjs": "^1.10.0",
-        "jsonld-streaming-serializer": "^1.1.0",
-        "lru-cache": "^6.0.0",
-        "n3": "^1.3.5"
       }
     },
     "node_modules/ansi-colors": {
@@ -6714,11 +4628,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrayify-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -6752,24 +4661,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/asynciterator": {
-      "version": "3.8.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/asyncjoin": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynciterator": "^3.6.0"
-      }
-    },
     "node_modules/attempt-x": {
       "version": "1.1.3",
       "license": "MIT",
@@ -6787,6 +4678,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/avro-js": {
+      "version": "1.11.5",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/avro-js/-/avro-js-1.11.5.tgz",
+      "integrity": "sha512-oevfVBGmLFF8CgUXnrw50Y7NKQZtsTtJIVOfa8b7cbQVmNcXSOzZLwjhM7a3EHdExU2sMP3WRiq2XD9kMLre4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "underscore": "^1.13.2"
+      }
+    },
+    "node_modules/avro-js/node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.7.0",
@@ -7107,11 +5015,6 @@
       ],
       "peer": true
     },
-    "node_modules/canonicalize": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/chai": {
       "version": "4.3.7",
       "dev": true,
@@ -7375,15 +5278,6 @@
       "version": "5.65.13",
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -7397,28 +5291,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -7540,37 +5416,6 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
-    },
-    "node_modules/componentsjs": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/minimist": "^1.2.0",
-        "@types/node": "^14.14.7",
-        "@types/semver": "^7.3.4",
-        "jsonld-context-parser": "^2.1.1",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-object": "^1.11.1",
-        "rdf-parse": "^1.9.1",
-        "rdf-quad": "^1.5.0",
-        "rdf-terms": "^1.7.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3"
-      },
-      "bin": {
-        "componentsjs-compile-config": "bin/compile-config.js"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/componentsjs/node_modules/@types/node": {
-      "version": "14.18.46",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7834,11 +5679,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
@@ -8163,11 +6003,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -9362,14 +7197,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "dev": true,
@@ -9534,11 +7361,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fetch-cookie": {
       "version": "0.11.0",
       "license": "Unlicense",
@@ -9547,30 +7369,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/fetch-sparql-endpoint": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.11",
-        "@types/sparqljs": "^3.1.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6",
-        "is-stream": "^2.0.0",
-        "minimist": "^1.2.0",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.6.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^1.7.0",
-        "sparqlxml-parse": "^1.5.0",
-        "stream-to-string": "^1.1.0"
-      },
-      "bin": {
-        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9667,30 +7465,6 @@
       "version": "3.2.7",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -10066,42 +7840,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/graphql-ld": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "graphql-to-sparql": "^2.4.0",
-        "jsonld-context-parser": "^2.1.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqljson-to-tree": "^2.1.0"
-      }
-    },
-    "node_modules/graphql-to-sparql": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "graphql": "^15.0.0",
-        "jsonld-context-parser": "^2.0.2",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "sparqlalgebrajs": "^3.0.2"
-      },
-      "bin": {
-        "graphql-to-sparql": "bin/graphql-to-sparql.js"
-      }
-    },
     "node_modules/growl": {
       "version": "1.10.5",
       "dev": true,
@@ -10232,20 +7970,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/hash.js/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -10342,14 +8066,6 @@
       "version": "2.0.4",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/http-link-header": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -10449,14 +8165,6 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "license": "MIT"
-    },
-    "node_modules/immutable": {
-      "version": "3.8.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -10630,11 +8338,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -11257,50 +8960,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/jsonld-context-parser": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-link-header": "^1.0.1",
-        "@types/node": "^18.0.0",
-        "canonicalize": "^1.0.1",
-        "cross-fetch": "^3.0.6",
-        "http-link-header": "^1.0.2",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "bin": {
-        "jsonld-context-parse": "bin/jsonld-context-parse.js"
-      }
-    },
-    "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.16.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsonld-streaming-parser": {
-      "version": "2.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/http-link-header": "^1.0.1",
-        "canonicalize": "^1.0.1",
-        "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/jsonld-streaming-serializer": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.0"
-      }
-    },
     "node_modules/jsonlint": {
       "version": "1.6.3",
       "dependencies": {
@@ -11540,11 +9199,6 @@
     },
     "node_modules/koa/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/kuler": {
-      "version": "2.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -12011,24 +9665,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/logform": {
-      "version": "2.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      }
-    },
-    "node_modules/logform/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "2.3.6",
       "dev": true,
@@ -12237,43 +9873,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/microdata-rdf-streaming-parser": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "dev": true,
@@ -12322,11 +9921,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -12710,55 +10304,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/n3": {
-      "version": "1.16.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/n3/node_modules/buffer": {
-      "version": "6.0.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/n3/node_modules/readable-stream": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/nan-x": {
       "version": "1.0.2",
       "license": "MIT",
@@ -12796,10 +10341,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiate": {
-      "version": "1.0.1",
-      "dev": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -13082,14 +10623,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "dev": true,
@@ -13267,14 +10800,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-link-header": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/parse5": {
@@ -13665,14 +11190,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -13680,11 +11197,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/promise-polyfill": {
-      "version": "1.1.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/property-is-enumerable-x": {
       "version": "1.1.0",
@@ -13886,175 +11398,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/rdf-data-factory": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/rdf-isomorphic": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.7.0"
-      }
-    },
-    "node_modules/rdf-js": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/rdf-literal": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-object": {
-      "version": "1.13.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "streamify-array": "^1.0.1"
-      }
-    },
-    "node_modules/rdf-parse": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-http-native": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
-        "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "node_modules/rdf-quad": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.1",
-        "rdf-literal": "^1.2.0",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "node_modules/rdf-store-stream": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "n3": "^1.11.1"
-      }
-    },
-    "node_modules/rdf-string": {
-      "version": "1.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-string-ttl": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/rdf-terms": {
-      "version": "1.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
-      }
-    },
-    "node_modules/rdfa-streaming-parser": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      }
-    },
-    "node_modules/rdfa-streaming-parser/node_modules/entities": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/rdfxml-streaming-parser": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.0",
-        "sax": "^1.2.4"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -14147,52 +11490,6 @@
         "inherits": "~2.0.1",
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/readable-stream-node-to-web": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/readdirp": {
@@ -14292,11 +11589,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
-    },
-    "node_modules/relative-to-absolute-iri": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/replace-comments-x": {
       "version": "2.0.0",
@@ -14604,31 +11896,9 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/sax-stream": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~2",
-        "sax": "~1"
-      }
     },
     "node_modules/scope-eval": {
       "version": "0.0.3",
@@ -14717,14 +11987,6 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "node_modules/sinon": {
       "version": "11.1.2",
@@ -14861,114 +12123,6 @@
       "version": "2.0.2",
       "license": "WTFPL"
     },
-    "node_modules/sparqlalgebrajs": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      },
-      "bin": {
-        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
-      }
-    },
-    "node_modules/sparqlee": {
-      "version": "1.10.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/spark-md5": "^3.0.2",
-        "@types/uuid": "^8.0.0",
-        "decimal.js": "^10.2.0",
-        "hash.js": "^1.1.7",
-        "immutable": "^3.8.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "relative-to-absolute-iri": "^1.0.6",
-        "spark-md5": "^3.0.1",
-        "sparqlalgebrajs": "^3.0.2",
-        "uuid": "^8.0.0"
-      },
-      "bin": {
-        "sparqlee": "dist/bin/Sparqlee.js"
-      }
-    },
-    "node_modules/sparqlee/node_modules/spark-md5": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/sparqlee/node_modules/uuid": {
-      "version": "8.3.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/sparqljs": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.1.1"
-      },
-      "bin": {
-        "sparqljs": "bin/sparql-to-json"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/sparqljson-parse": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "JSONStream": "^1.3.3",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/sparqljson-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/sparqljson-to-tree": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rdf-literal": "^1.2.0",
-        "sparqljson-parse": "^1.6.0"
-      }
-    },
-    "node_modules/sparqlxml-parse": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "rdf-data-factory": "^1.1.0",
-        "sax-stream": "^1.2.3"
-      }
-    },
-    "node_modules/sparqlxml-parse/node_modules/@types/node": {
-      "version": "13.13.52",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -15052,14 +12206,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "dev": true,
@@ -15067,24 +12213,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/stream-to-string": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-polyfill": "^1.1.6"
-      }
-    },
-    "node_modules/streamify-array": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/streamify-string": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -15405,11 +12533,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -15632,11 +12755,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "9.1.1",
@@ -15947,10 +13065,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uritemplate": {
-      "version": "0.3.4",
-      "dev": true
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "license": "MIT",
@@ -16075,29 +13189,6 @@
       "version": "1.0.3",
       "license": "Apache-2.0"
     },
-    "node_modules/web-streams-node": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-stream": "^1.1.0",
-        "readable-stream-node-to-web": "^1.0.1",
-        "web-streams-ponyfill": "^1.4.1"
-      }
-    },
-    "node_modules/web-streams-node/node_modules/is-stream": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/web-streams-ponyfill": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause"
@@ -16215,92 +13306,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/winston": {
-      "version": "3.8.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/winston-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/winston-transport/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/winston/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/winston/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/winston/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/word-wrap": {
@@ -16425,11 +13430,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -17237,6 +14237,12 @@
     "@advanced-rest-client/uuid-generator": {
       "version": "3.1.2"
     },
+    "@aml-org/amf-antlr-parsers": {
+      "version": "0.9.154",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aml-org/amf-antlr-parsers/-/amf-antlr-parsers-0.9.154.tgz",
+      "integrity": "sha512-eXptBQVW/EuCiRAXl1qtOeMBQS9fFJKqMOH9b/PdvSAnIIFmrg/itqKsUdpnFRxFd0o9NYthbM/8Vc8sViBFQw==",
+      "dev": true
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -17450,9 +14456,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.5.34",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.34.tgz",
-      "integrity": "sha512-zw3169JqvFI4FpJY2ne9mfI0Z70rs4xpxve/cxPHsVQLbBJyAtjsGt/3xMm52ci5uVHtzdQ5yVTSrlHUDtA0LA==",
+      "version": "4.5.38",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.38.tgz",
+      "integrity": "sha512-v1sWZ9MevGOllbVtHC19IZ1BlkHlSq4FUerAyoquc3pKLMGYg5h0HyGYsgYKDyi+HSAYJUcpPGAq7YqZC/2ZYQ==",
       "requires": {
         "amf-json-ld-lib": "0.0.14"
       }
@@ -17673,10 +14679,12 @@
       }
     },
     "@api-components/api-model-generator": {
-      "version": "0.2.14",
+      "version": "0.4.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@api-components/api-model-generator/-/api-model-generator-0.4.0.tgz",
+      "integrity": "sha512-r/XlbF+A0DmxbqhmqSs+gX4T0n7RxLoag9hqIBo8a+kPZ99xO0NDXTFosqCZD4qD10tt2QDfWeU8BPgWOadOOw==",
       "dev": true,
       "requires": {
-        "amf-client-js": "^4.7.6",
+        "amf-client-js": "5.11.12531",
         "fs-extra": "^10.0.0"
       }
     },
@@ -18294,10 +15302,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@colors/colors": {
-      "version": "1.5.0",
-      "dev": true
-    },
     "@commitlint/cli": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-13.2.1.tgz",
@@ -18623,1392 +15627,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
-      }
-    },
-    "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "canonicalize": "^1.0.1",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-abstract-mediatyped": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-abstract-path": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0"
-      }
-    },
-    "@comunica/actor-http-memento": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "parse-link-header": "^1.0.1"
-      }
-    },
-    "@comunica/actor-http-native": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/parse-link-header": "^1.0.0",
-        "cross-fetch": "^3.0.5",
-        "follow-redirects": "^1.5.1",
-        "parse-link-header": "^1.0.1"
-      }
-    },
-    "@comunica/actor-http-node-fetch": {
-      "version": "1.22.3",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "cross-fetch": "^3.0.5"
-      }
-    },
-    "@comunica/actor-http-proxy": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-init-sparql": {
-      "version": "1.22.3",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-context-preprocess-source-to-destination": "^1.22.0",
-        "@comunica/actor-http-memento": "^1.22.1",
-        "@comunica/actor-http-native": "^1.22.1",
-        "@comunica/actor-http-node-fetch": "^1.22.3",
-        "@comunica/actor-http-proxy": "^1.22.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.22.0",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-group": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-minus": "^1.22.0",
-        "@comunica/actor-query-operation-nop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-reduced-hash": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.22.2",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-update-add-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-clear": "^1.22.0",
-        "@comunica/actor-query-operation-update-compositeupdate": "^1.22.0",
-        "@comunica/actor-query-operation-update-copy-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-update-create": "^1.22.0",
-        "@comunica/actor-query-operation-update-deleteinsert": "^1.22.2",
-        "@comunica/actor-query-operation-update-drop": "^1.22.0",
-        "@comunica/actor-query-operation-update-load": "^1.22.0",
-        "@comunica/actor-query-operation-update-move-rewrite": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-dereference-fallback": "^1.22.2",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.22.3",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.22.0",
-        "@comunica/actor-rdf-metadata-all": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-metadata-extract-put-accepted": "^1.22.0",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.22.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.22.0",
-        "@comunica/actor-rdf-parse-html": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "^1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.1",
-        "@comunica/actor-rdf-parse-n3": "^1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.22.0",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.22.2",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.22.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^1.22.2",
-        "@comunica/actor-rdf-update-hypermedia-sparql": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^1.22.2",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^1.22.2",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-parse-graphql": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/actor-sparql-serialize-stats": "^1.22.1",
-        "@comunica/actor-sparql-serialize-table": "^1.22.0",
-        "@comunica/actor-sparql-serialize-tree": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/bus-http-invalidate": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-optimize-query-operation": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-dereference-paged": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-parse": "^1.22.0",
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.22.0",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/logger-pretty": "^1.22.0",
-        "@comunica/logger-void": "^1.22.0",
-        "@comunica/mediator-all": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.2",
-        "asynciterator": "^3.2.0",
-        "negotiate": "^1.0.1",
-        "rdf-quad": "^1.4.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0",
-        "streamify-string": "^1.0.1",
-        "yargs": "^17.1.1"
-      }
-    },
-    "@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.22.3",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/actor-init-sparql": "^1.22.3",
-        "@comunica/actor-query-operation-ask": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.22.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.22.0",
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.22.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.22.0",
-        "@comunica/actor-query-operation-extend": "^1.22.0",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-from-quad": "^1.22.0",
-        "@comunica/actor-query-operation-join": "^1.22.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.22.0",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.22.0",
-        "@comunica/actor-query-operation-path-alt": "^1.22.0",
-        "@comunica/actor-query-operation-path-inv": "^1.22.0",
-        "@comunica/actor-query-operation-path-link": "^1.22.0",
-        "@comunica/actor-query-operation-path-nps": "^1.22.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-seq": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.22.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.22.0",
-        "@comunica/actor-query-operation-project": "^1.22.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.22.0",
-        "@comunica/actor-query-operation-service": "^1.22.3",
-        "@comunica/actor-query-operation-slice": "^1.22.0",
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/actor-query-operation-values": "^1.22.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.22.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.22.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.22.0",
-        "@comunica/actor-sparql-serialize-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.22.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.22.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.22.0",
-        "@comunica/bus-context-preprocess": "^1.22.0",
-        "@comunica/bus-init": "^1.22.0",
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-serialize": "^1.22.0",
-        "@comunica/bus-sparql-parse": "^1.22.0",
-        "@comunica/bus-sparql-serialize": "^1.22.0",
-        "@comunica/core": "^1.22.0",
-        "@comunica/mediator-combine-pipeline": "^1.22.0",
-        "@comunica/mediator-combine-union": "^1.22.0",
-        "@comunica/mediator-number": "^1.22.0",
-        "@comunica/mediator-race": "^1.22.0",
-        "@comunica/runner": "^1.22.0",
-        "@comunica/runner-cli": "^1.22.0"
-      }
-    },
-    "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-ask": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-construct": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-query-operation-union": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-extend": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqlee": "^1.10.0"
-      }
-    },
-    "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      }
-    },
-    "@comunica/actor-query-operation-from-quad": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-group": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      }
-    },
-    "@comunica/actor-query-operation-join": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-join": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      }
-    },
-    "@comunica/actor-query-operation-minus": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-nop": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.1"
-      }
-    },
-    "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqlee": "^1.10.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-alt": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-inv": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-link": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-nps": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-seq": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-path": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-project": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-service": {
-      "version": "1.22.3",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-slice": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "arrayify-stream": "^1.0.0",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-union": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-update-add-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-update-clear": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4"
-      }
-    },
-    "@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-query-operation-update-copy-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-update-create": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-query-operation-construct": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@comunica/actor-query-operation-update-drop": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4"
-      }
-    },
-    "@comunica/actor-query-operation-update-load": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-update-move-rewrite": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.4",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-query-operation-values": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asynciterator": "^3.2.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-rdf-dereference-fallback": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.22.3",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^3.0.5",
-        "relative-to-absolute-iri": "^1.0.5",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/mediatortype-iterations": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      }
-    },
-    "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      }
-    },
-    "@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "asyncjoin": "^1.0.3"
-      }
-    },
-    "@comunica/actor-rdf-metadata-all": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-rdf-metadata-extract-allow-http-methods": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/uritemplate": "^0.3.4",
-        "uritemplate": "0.3.4"
-      }
-    },
-    "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-metadata-extract-put-accepted": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "relative-to-absolute-iri": "^1.0.5"
-      }
-    },
-    "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-rdf-parse-html": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "htmlparser2": "^7.0.0"
-      }
-    },
-    "@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "microdata-rdf-streaming-parser": "^1.2.0"
-      }
-    },
-    "@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdfa-streaming-parser": "^1.5.0"
-      }
-    },
-    "@comunica/actor-rdf-parse-html-script": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.22.0",
-        "@rdfjs/types": "*",
-        "relative-to-absolute-iri": "^1.0.5"
-      }
-    },
-    "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.1.2",
-        "jsonld-streaming-parser": "^2.4.0",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "@comunica/actor-rdf-parse-n3": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3"
-      }
-    },
-    "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdfxml-streaming-parser": "^1.5.0"
-      }
-    },
-    "@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "rdfa-streaming-parser": "^1.5.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-store-stream": "^1.3.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2"
-      }
-    },
-    "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^1.22.0",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@comunica/utils-datasource": "^1.22.2",
-        "@rdfjs/types": "*",
-        "@types/lru-cache": "^5.1.0",
-        "asynciterator": "^3.2.0",
-        "lru-cache": "^6.0.0",
-        "rdf-data-factory": "^1.0.3",
-        "rdf-string": "^1.5.0",
-        "rdf-terms": "^1.6.2",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "jsonld-streaming-serializer": "^1.3.0"
-      }
-    },
-    "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/n3": "^1.4.4",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5",
-        "rdf-string-ttl": "^1.1.0"
-      }
-    },
-    "@comunica/actor-rdf-update-hypermedia-put-ldp": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "cross-fetch": "^3.0.5"
-      }
-    },
-    "@comunica/actor-rdf-update-hypermedia-sparql": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "fetch-sparql-endpoint": "^2.3.2",
-        "rdf-string-ttl": "^1.1.0",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-dereference": "^1.22.2",
-        "@comunica/bus-rdf-metadata": "^1.22.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.22.0",
-        "@comunica/bus-rdf-update-hypermedia": "^1.22.2",
-        "@types/lru-cache": "^5.1.0",
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "rdf-data-factory": "^1.0.4",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@types/sparqljs": "^3.0.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "sparqljs": "^3.4.1"
-      }
-    },
-    "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "graphql-to-sparql": "^2.4.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-json": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-query-operation": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-string-ttl": "^1.1.0"
-      }
-    },
-    "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "@types/xml": "^1.0.2",
-        "xml": "^1.0.1"
-      }
-    },
-    "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/actor-sparql-serialize-table": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.6.2"
-      }
-    },
-    "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "sparqljson-to-tree": "^2.0.0"
-      }
-    },
-    "@comunica/bus-context-preprocess": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/bus-http": {
-      "version": "1.22.1",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@types/readable-stream": "^2.3.11",
-        "is-stream": "^2.0.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "web-streams-node": "^0.4.0"
-      }
-    },
-    "@comunica/bus-http-invalidate": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/bus-init": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/bus-optimize-query-operation": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/bus-query-operation": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/data-factory": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/bus-rdf-dereference": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@comunica/bus-rdf-join": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@comunica/bus-rdf-metadata": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/types": "^1.22.0",
-        "@rdfjs/types": "*",
-        "graphql-ld": "^1.4.0",
-        "rdf-store-stream": "^1.3.0",
-        "sparqlalgebrajs": "^3.0.0",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "@comunica/bus-rdf-parse": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/bus-rdf-parse-html": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/bus-rdf-serialize": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/bus-rdf-update-hypermedia": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-update-quads": "^1.22.2"
-      }
-    },
-    "@comunica/bus-rdf-update-quads": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-http": "^1.22.1",
-        "@comunica/context-entries": "^1.22.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "@comunica/bus-sparql-parse": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "sparqlalgebrajs": "^3.0.0"
-      }
-    },
-    "@comunica/bus-sparql-serialize": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.22.0",
-        "@comunica/types": "^1.22.0"
-      }
-    },
-    "@comunica/context-entries": {
-      "version": "1.22.0",
-      "dev": true
-    },
-    "@comunica/core": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/context-entries": "^1.22.0",
-        "@comunica/types": "^1.22.0",
-        "immutable": "^3.8.2"
-      }
-    },
-    "@comunica/data-factory": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "@comunica/logger-pretty": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/logger-void": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediator-all": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediator-combine-pipeline": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediator-combine-union": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediator-number": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediator-race": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/mediatortype-iterations": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {}
-    },
-    "@comunica/runner": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "componentsjs": "^4.0.6"
-      }
-    },
-    "@comunica/runner-cli": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@comunica/runner": "^1.22.0"
-      }
-    },
-    "@comunica/types": {
-      "version": "1.22.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.2.0",
-        "immutable": "^3.8.2",
-        "sparqlalgebrajs": "^3.0.1"
-      }
-    },
-    "@comunica/utils-datasource": {
-      "version": "1.22.2",
-      "dev": true,
-      "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.22.0",
-        "@comunica/bus-rdf-update-quads": "^1.22.2",
-        "@comunica/context-entries": "^1.22.0",
-        "asynciterator": "^3.2.0"
-      }
-    },
-    "@dabh/diagnostics": {
-      "version": "2.0.3",
-      "dev": true,
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
       }
     },
     "@emmetio/extract-abbreviation": {
@@ -20629,13 +16247,6 @@
         "prismjs": "^1.11.0"
       }
     },
-    "@rdfjs/types": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "13.3.0",
       "dev": true,
@@ -20795,13 +16406,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "@types/http-link-header": {
-      "version": "1.0.3",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true
@@ -20849,10 +16453,6 @@
         "@types/koa": "*"
       }
     },
-    "@types/lru-cache": {
-      "version": "5.1.1",
-      "dev": true
-    },
     "@types/mime": {
       "version": "1.3.2",
       "dev": true
@@ -20864,14 +16464,6 @@
     "@types/mocha": {
       "version": "5.2.7",
       "dev": true
-    },
-    "@types/n3": {
-      "version": "1.10.4",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "rdf-js": "^4.0.2"
-      }
     },
     "@types/node": {
       "version": "20.1.2",
@@ -20885,10 +16477,6 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "dev": true
-    },
-    "@types/parse-link-header": {
-      "version": "1.0.1",
       "dev": true
     },
     "@types/parse5": {
@@ -20906,30 +16494,12 @@
       "version": "1.2.4",
       "dev": true
     },
-    "@types/readable-stream": {
-      "version": "2.3.15",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        }
-      }
-    },
     "@types/resolve": {
       "version": "1.17.1",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/semver": {
-      "version": "7.5.0",
-      "dev": true
     },
     "@types/send": {
       "version": "0.17.1",
@@ -20966,53 +16536,12 @@
       "version": "8.1.2",
       "dev": true
     },
-    "@types/spark-md5": {
-      "version": "3.0.2",
-      "dev": true
-    },
-    "@types/sparqljs": {
-      "version": "3.1.4",
-      "dev": true,
-      "requires": {
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "@types/triple-beam": {
-      "version": "1.3.2",
-      "dev": true
-    },
-    "@types/uritemplate": {
-      "version": "0.3.4",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "dev": true
-    },
     "@types/ws": {
       "version": "7.4.7",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/xml": {
-      "version": "1.0.8",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/yargs": {
-      "version": "17.0.24",
-      "dev": true,
-      "requires": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "@types/yargs-parser": {
-      "version": "21.0.0",
-      "dev": true
     },
     "@types/yauzl": {
       "version": "2.10.0",
@@ -21553,29 +17082,72 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.20.0",
+          "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv/-/ajv-8.20.0.tgz",
+          "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "amdefine": {
       "version": "1.0.1"
     },
     "amf-client-js": {
-      "version": "4.7.8",
+      "version": "5.11.12531",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/amf-client-js/-/amf-client-js-5.11.12531.tgz",
+      "integrity": "sha512-zAc/PwsOfsNzgii7LAsuJrYx+qXUBlOkd3Mwz3YD9r+jZjpJkEeDmxtb+N4F+Z5dy/g3i6J0kMfgeVYWCUOwtA==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.6",
-        "amf-shacl-node": "2.0.0"
+        "@aml-org/amf-antlr-parsers": "0.9.154",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
+        "avro-js": "1.11.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.20.0",
+          "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/ajv/-/ajv-8.20.0.tgz",
+          "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "amf-json-ld-lib": {
       "version": "0.0.14"
-    },
-    "amf-shacl-node": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-init-sparql-rdfjs": "^1.10.0",
-        "jsonld-streaming-serializer": "^1.1.0",
-        "lru-cache": "^6.0.0",
-        "n3": "^1.3.5"
-      }
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -21695,10 +17267,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "arrayify-stream": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -21716,27 +17284,29 @@
       "version": "2.0.0",
       "dev": true
     },
-    "async": {
-      "version": "3.2.4",
-      "dev": true
-    },
-    "asynciterator": {
-      "version": "3.8.0",
-      "dev": true
-    },
-    "asyncjoin": {
-      "version": "1.1.2",
-      "dev": true,
-      "requires": {
-        "asynciterator": "^3.6.0"
-      }
-    },
     "attempt-x": {
       "version": "1.1.3"
     },
     "available-typed-arrays": {
       "version": "1.0.5",
       "dev": true
+    },
+    "avro-js": {
+      "version": "1.11.5",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/avro-js/-/avro-js-1.11.5.tgz",
+      "integrity": "sha512-oevfVBGmLFF8CgUXnrw50Y7NKQZtsTtJIVOfa8b7cbQVmNcXSOzZLwjhM7a3EHdExU2sMP3WRiq2XD9kMLre4g==",
+      "dev": true,
+      "requires": {
+        "underscore": "^1.13.2"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.13.8",
+          "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/underscore/-/underscore-1.13.8.tgz",
+          "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+          "dev": true
+        }
+      }
     },
     "axe-core": {
       "version": "4.7.0",
@@ -21915,10 +17485,6 @@
       "dev": true,
       "peer": true
     },
-    "canonicalize": {
-      "version": "1.0.8",
-      "dev": true
-    },
     "chai": {
       "version": "4.3.7",
       "dev": true,
@@ -22083,14 +17649,6 @@
     "codemirror": {
       "version": "5.65.13"
     },
-    "color": {
-      "version": "3.2.1",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -22102,25 +17660,9 @@
       "version": "1.1.3",
       "dev": true
     },
-    "color-string": {
-      "version": "1.9.1",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "colorette": {
       "version": "1.4.0",
       "dev": true
-    },
-    "colorspace": {
-      "version": "1.1.4",
-      "dev": true,
-      "requires": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "command-line-args": {
       "version": "5.2.1",
@@ -22202,31 +17744,6 @@
       "requires": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
-      }
-    },
-    "componentsjs": {
-      "version": "4.5.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/minimist": "^1.2.0",
-        "@types/node": "^14.14.7",
-        "@types/semver": "^7.3.4",
-        "jsonld-context-parser": "^2.1.1",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-object": "^1.11.1",
-        "rdf-parse": "^1.9.1",
-        "rdf-quad": "^1.5.0",
-        "rdf-terms": "^1.7.0",
-        "semver": "^7.3.2",
-        "winston": "^3.3.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.46",
-          "dev": true
-        }
       }
     },
     "concat-map": {
@@ -22415,10 +17932,6 @@
           "dev": true
         }
       }
-    },
-    "decimal.js": {
-      "version": "10.4.3",
-      "dev": true
     },
     "deep-eql": {
       "version": "4.1.3",
@@ -22632,10 +18145,6 @@
     },
     "emoji-regex": {
       "version": "8.0.0",
-      "dev": true
-    },
-    "enabled": {
-      "version": "2.0.0",
       "dev": true
     },
     "encodeurl": {
@@ -23442,10 +18951,6 @@
     "event-target-shim": {
       "version": "5.0.1"
     },
-    "events": {
-      "version": "3.3.0",
-      "dev": true
-    },
     "execa": {
       "version": "5.1.1",
       "dev": true,
@@ -23550,34 +19055,10 @@
         "pend": "~1.2.0"
       }
     },
-    "fecha": {
-      "version": "4.2.3",
-      "dev": true
-    },
     "fetch-cookie": {
       "version": "0.11.0",
       "requires": {
         "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
-      }
-    },
-    "fetch-sparql-endpoint": {
-      "version": "2.4.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/readable-stream": "^2.3.11",
-        "@types/sparqljs": "^3.1.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6",
-        "is-stream": "^2.0.0",
-        "minimist": "^1.2.0",
-        "n3": "^1.6.3",
-        "rdf-string": "^1.6.0",
-        "readable-web-to-node-stream": "^3.0.2",
-        "sparqljs": "^3.1.2",
-        "sparqljson-parse": "^1.7.0",
-        "sparqlxml-parse": "^1.5.0",
-        "stream-to-string": "^1.1.0"
       }
     },
     "file-entry-cache": {
@@ -23632,14 +19113,6 @@
     },
     "flatted": {
       "version": "3.2.7",
-      "dev": true
-    },
-    "fn.name": {
-      "version": "1.1.0",
-      "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
       "dev": true
     },
     "for-each": {
@@ -23888,33 +19361,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "graphql": {
-      "version": "15.8.0",
-      "dev": true
-    },
-    "graphql-ld": {
-      "version": "1.4.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "graphql-to-sparql": "^2.4.0",
-        "jsonld-context-parser": "^2.1.0",
-        "sparqlalgebrajs": "^3.0.2",
-        "sparqljson-to-tree": "^2.1.0"
-      }
-    },
-    "graphql-to-sparql": {
-      "version": "2.4.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "graphql": "^15.0.0",
-        "jsonld-context-parser": "^2.0.2",
-        "minimist": "^1.2.0",
-        "rdf-data-factory": "^1.1.0",
-        "sparqlalgebrajs": "^3.0.2"
-      }
-    },
     "growl": {
       "version": "1.10.5",
       "dev": true
@@ -23984,20 +19430,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "dev": true
-        }
-      }
-    },
     "hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -24063,10 +19495,6 @@
         }
       }
     },
-    "http-link-header": {
-      "version": "1.1.1",
-      "dev": true
-    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "dev": true,
@@ -24115,10 +19543,6 @@
     },
     "immediate": {
       "version": "3.0.6"
-    },
-    "immutable": {
-      "version": "3.8.2",
-      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -24231,10 +19655,6 @@
         "object-get-own-property-descriptor-x": "^3.2.0",
         "to-string-tag-x": "^1.4.1"
       }
-    },
-    "is-arrayish": {
-      "version": "0.3.2",
-      "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -24608,45 +20028,6 @@
     "jsonify": {
       "version": "0.0.1"
     },
-    "jsonld-context-parser": {
-      "version": "2.3.0",
-      "dev": true,
-      "requires": {
-        "@types/http-link-header": "^1.0.1",
-        "@types/node": "^18.0.0",
-        "canonicalize": "^1.0.1",
-        "cross-fetch": "^3.0.6",
-        "http-link-header": "^1.0.2",
-        "relative-to-absolute-iri": "^1.0.5"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.16.7",
-          "dev": true
-        }
-      }
-    },
-    "jsonld-streaming-parser": {
-      "version": "2.4.3",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/http-link-header": "^1.0.1",
-        "canonicalize": "^1.0.1",
-        "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "jsonld-streaming-serializer": {
-      "version": "1.3.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.0"
-      }
-    },
     "jsonlint": {
       "version": "1.6.3",
       "requires": {
@@ -24809,10 +20190,6 @@
           "dev": true
         }
       }
-    },
-    "kuler": {
-      "version": "2.0.0",
-      "dev": true
     },
     "level": {
       "version": "6.0.1",
@@ -25132,24 +20509,6 @@
         }
       }
     },
-    "logform": {
-      "version": "2.5.1",
-      "dev": true,
-      "requires": {
-        "@colors/colors": "1.5.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "dev": true
-        }
-      }
-    },
     "loupe": {
       "version": "2.3.6",
       "dev": true,
@@ -25281,32 +20640,6 @@
       "version": "1.4.1",
       "dev": true
     },
-    "microdata-rdf-streaming-parser": {
-      "version": "1.2.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "6.1.0",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
-          }
-        }
-      }
-    },
     "micromatch": {
       "version": "4.0.5",
       "dev": true,
@@ -25334,10 +20667,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
       "dev": true
     },
     "minimatch": {
@@ -25600,34 +20929,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "n3": {
-      "version": "1.16.4",
-      "dev": true,
-      "requires": {
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.4.0",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        }
-      }
-    },
     "nan-x": {
       "version": "1.0.2"
     },
@@ -25644,10 +20945,6 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "dev": true
-    },
-    "negotiate": {
-      "version": "1.0.1",
       "dev": true
     },
     "negotiator": {
@@ -25840,13 +21137,6 @@
         "wrappy": "1"
       }
     },
-    "one-time": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "fn.name": "1.x.x"
-      }
-    },
     "onetime": {
       "version": "5.1.2",
       "dev": true,
@@ -25954,13 +21244,6 @@
         "error-ex": "^1.3.1",
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
-      }
-    },
-    "parse-link-header": {
-      "version": "1.0.1",
-      "dev": true,
-      "requires": {
-        "xtend": "~4.0.1"
       }
     },
     "parse5": {
@@ -26260,16 +21543,8 @@
     "private": {
       "version": "0.1.8"
     },
-    "process": {
-      "version": "0.11.10",
-      "dev": true
-    },
     "progress": {
       "version": "2.0.3",
-      "dev": true
-    },
-    "promise-polyfill": {
-      "version": "1.1.6",
       "dev": true
     },
     "property-is-enumerable-x": {
@@ -26390,152 +21665,6 @@
         }
       }
     },
-    "rdf-data-factory": {
-      "version": "1.1.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "rdf-isomorphic": {
-      "version": "1.3.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "hash.js": "^1.1.7",
-        "rdf-string": "^1.6.0",
-        "rdf-terms": "^1.7.0"
-      }
-    },
-    "rdf-js": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "rdf-literal": {
-      "version": "1.3.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "rdf-object": {
-      "version": "1.13.2",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.0.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "streamify-array": "^1.0.1"
-      }
-    },
-    "rdf-parse": {
-      "version": "1.9.1",
-      "dev": true,
-      "requires": {
-        "@comunica/actor-http-native": "~1.22.0",
-        "@comunica/actor-rdf-parse-html": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-microdata": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-rdfa": "~1.22.0",
-        "@comunica/actor-rdf-parse-html-script": "~1.22.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.22.0",
-        "@comunica/actor-rdf-parse-n3": "~1.22.0",
-        "@comunica/actor-rdf-parse-rdfxml": "~1.22.0",
-        "@comunica/actor-rdf-parse-xml-rdfa": "~1.22.0",
-        "@comunica/bus-http": "~1.22.0",
-        "@comunica/bus-init": "~1.22.0",
-        "@comunica/bus-rdf-parse": "~1.22.0",
-        "@comunica/bus-rdf-parse-html": "~1.22.0",
-        "@comunica/core": "~1.22.0",
-        "@comunica/mediator-combine-union": "~1.22.0",
-        "@comunica/mediator-number": "~1.22.0",
-        "@comunica/mediator-race": "~1.22.0",
-        "@rdfjs/types": "*",
-        "stream-to-string": "^1.2.0"
-      }
-    },
-    "rdf-quad": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.0.1",
-        "rdf-literal": "^1.2.0",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "rdf-store-stream": {
-      "version": "1.3.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "n3": "^1.11.1"
-      }
-    },
-    "rdf-string": {
-      "version": "1.6.3",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "rdf-string-ttl": {
-      "version": "1.3.2",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "rdf-terms": {
-      "version": "1.9.1",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
-      }
-    },
-    "rdfa-streaming-parser": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "htmlparser2": "^6.0.0",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.2"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "6.1.0",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.5.2",
-            "entities": "^2.0.0"
-          }
-        }
-      }
-    },
-    "rdfxml-streaming-parser": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "relative-to-absolute-iri": "^1.0.0",
-        "sax": "^1.2.4"
-      }
-    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -26608,39 +21737,6 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "readable-stream-node-to-web": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -26696,10 +21792,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
-    },
-    "relative-to-absolute-iri": {
-      "version": "1.0.7",
       "dev": true
     },
     "replace-comments-x": {
@@ -26885,24 +21977,8 @@
         "is-regex": "^1.1.4"
       }
     },
-    "safe-stable-stringify": {
-      "version": "2.4.3",
-      "dev": true
-    },
     "safer-buffer": {
       "version": "2.1.2"
-    },
-    "sax": {
-      "version": "1.2.4",
-      "dev": true
-    },
-    "sax-stream": {
-      "version": "1.3.0",
-      "dev": true,
-      "requires": {
-        "debug": "~2",
-        "sax": "~1"
-      }
     },
     "scope-eval": {
       "version": "0.0.3"
@@ -26963,13 +22039,6 @@
     "signal-exit": {
       "version": "3.0.7",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "sinon": {
       "version": "11.1.2",
@@ -27064,95 +22133,6 @@
     "spark-md5": {
       "version": "2.0.2"
     },
-    "sparqlalgebrajs": {
-      "version": "3.0.3",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/sparqljs": "^3.1.2",
-        "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-isomorphic": "^1.3.0",
-        "rdf-string": "^1.6.0",
-        "sparqljs": "^3.4.2"
-      }
-    },
-    "sparqlee": {
-      "version": "1.10.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/spark-md5": "^3.0.2",
-        "@types/uuid": "^8.0.0",
-        "decimal.js": "^10.2.0",
-        "hash.js": "^1.1.7",
-        "immutable": "^3.8.2",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0",
-        "relative-to-absolute-iri": "^1.0.6",
-        "spark-md5": "^3.0.1",
-        "sparqlalgebrajs": "^3.0.2",
-        "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "spark-md5": {
-          "version": "3.0.2",
-          "dev": true
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "dev": true
-        }
-      }
-    },
-    "sparqljs": {
-      "version": "3.6.2",
-      "dev": true,
-      "requires": {
-        "rdf-data-factory": "^1.1.1"
-      }
-    },
-    "sparqljson-parse": {
-      "version": "1.7.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "JSONStream": "^1.3.3",
-        "rdf-data-factory": "^1.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "dev": true
-        }
-      }
-    },
-    "sparqljson-to-tree": {
-      "version": "2.1.0",
-      "dev": true,
-      "requires": {
-        "rdf-literal": "^1.2.0",
-        "sparqljson-parse": "^1.6.0"
-      }
-    },
-    "sparqlxml-parse": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/node": "^13.1.0",
-        "rdf-data-factory": "^1.1.0",
-        "sax-stream": "^1.2.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "dev": true
-        }
-      }
-    },
     "spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -27226,27 +22206,8 @@
       "version": "1.0.3",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "dev": true
-    },
     "statuses": {
       "version": "1.5.0",
-      "dev": true
-    },
-    "stream-to-string": {
-      "version": "1.2.1",
-      "dev": true,
-      "requires": {
-        "promise-polyfill": "^1.1.6"
-      }
-    },
-    "streamify-array": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "streamify-string": {
-      "version": "1.0.1",
       "dev": true
     },
     "string_decoder": {
@@ -27464,10 +22425,6 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
-    "text-hex": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "dev": true
@@ -27617,10 +22574,6 @@
         "trim-left-x": "^3.0.0",
         "trim-right-x": "^3.0.0"
       }
-    },
-    "triple-beam": {
-      "version": "1.3.0",
-      "dev": true
     },
     "ts-node": {
       "version": "9.1.1",
@@ -27811,10 +22764,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "uritemplate": {
-      "version": "0.3.4",
-      "dev": true
-    },
     "url-parse": {
       "version": "1.5.10",
       "requires": {
@@ -27911,25 +22860,6 @@
     "vuvuzela": {
       "version": "1.0.3"
     },
-    "web-streams-node": {
-      "version": "0.4.0",
-      "dev": true,
-      "requires": {
-        "is-stream": "^1.1.0",
-        "readable-stream-node-to-web": "^1.0.1",
-        "web-streams-ponyfill": "^1.4.1"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "dev": true
-        }
-      }
-    },
-    "web-streams-ponyfill": {
-      "version": "1.4.2",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "3.0.1"
     },
@@ -28005,76 +22935,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
-    "winston": {
-      "version": "3.8.2",
-      "dev": true,
-      "requires": {
-        "@colors/colors": "1.5.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "winston-transport": {
-      "version": "4.5.0",
-      "dev": true,
-      "requires": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
-        "triple-beam": "^1.3.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.2",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
           }
         }
       }
@@ -28155,10 +23015,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "requires": {}
-    },
-    "xml": {
-      "version": "1.0.1",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-documentation",
   "description": "A main documentation view for AMF model",
-  "version": "6.1.8",
+  "version": "6.1.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@advanced-rest-client/events-target-mixin": "^3.2.4",
-    "@api-components/amf-helper-mixin": "^4.5.1",
+    "@api-components/amf-helper-mixin": "^4.5.38",
     "@api-components/api-documentation-document": "^4.1.0",
     "@api-components/api-endpoint-documentation": "^6.1.3",
     "@api-components/api-method-documentation": "^5.2.30",
@@ -43,7 +43,7 @@
     "@anypoint-web-components/anypoint-checkbox": "^1.2.2",
     "@anypoint-web-components/anypoint-input": "^0.2.27",
     "@anypoint-web-components/anypoint-styles": "^1.0.2",
-    "@api-components/api-model-generator": "^0.2.14",
+    "@api-components/api-model-generator": "^0.4.0",
     "@api-components/api-navigation": "^4.3.20",
     "@api-components/api-request": "^0.2.1",
     "@commitlint/cli": "^13.2.1",

--- a/src/ApiDocumentationElement.d.ts
+++ b/src/ApiDocumentationElement.d.ts
@@ -156,6 +156,10 @@ export class ApiDocumentationElement extends EventsTargetMixin(AmfHelperMixin(Li
   // Currently rendered view type
   _viewType: string;
   /**
+   * Backing field for the `selectedType` accessor.
+   */
+  _selectedType: string;
+  /**
    * Computed value of the final model extracted from the `amf`, `selected`,
    * and `selectedType` properties.
    */
@@ -201,6 +205,21 @@ export class ApiDocumentationElement extends EventsTargetMixin(AmfHelperMixin(Li
   get showsSelector(): boolean;
 
   get effectiveBaseUri(): string;
+
+  /**
+   * Computes whether the "Try It" button should be hidden. True when `noTryIt`
+   * is set, when the selected operation is gRPC, or when it is an OAS 3.1/3.2
+   * top-level webhook.
+   */
+  get effectiveNoTryIt(): boolean;
+
+  /**
+   * Determines whether an operation belongs to the API's top-level webhooks
+   * collection (OAS 3.1/3.2).
+   * @param operation The selected operation model.
+   * @returns True when the operation is a top-level webhook operation.
+   */
+  _isWebhookOperation(operation: any): boolean;
 
   constructor();
 

--- a/src/ApiDocumentationElement.js
+++ b/src/ApiDocumentationElement.js
@@ -242,23 +242,66 @@ export class ApiDocumentationElement extends EventsTargetMixin(AmfHelperMixin(Li
 
   /**
    * Computes whether the "Try It" button should be hidden.
-   * Returns true if noTryIt is explicitly set or if the current operation is gRPC.
+   * Returns true if noTryIt is explicitly set, if the current operation is gRPC,
+   * or if the current operation is an OAS 3.1/3.2 top-level webhook.
    * @returns {boolean}
    */
   get effectiveNoTryIt() {
     const { noTryIt, _docsModel, selectedType } = this;
-    
+
     // If noTryIt is explicitly set, respect that
     if (noTryIt) {
       return true;
     }
-    
-    // If we're viewing a method and it's a gRPC operation, hide Try It
+
+    // If we're viewing a method, hide Try It when it's a gRPC operation or a
+    // top-level webhook. Suppression is per-operation: a webhook API may still
+    // expose invokable REST endpoints, which keep Try It.
     if (selectedType === 'method' && _docsModel) {
-      return this._isGrpcOperation(_docsModel);
+      return this._isGrpcOperation(_docsModel) || this._isWebhookOperation(_docsModel);
     }
-    
+
     return false;
+  }
+
+  /**
+   * Determines whether an operation belongs to the API's top-level webhooks
+   * collection (OAS 3.1/3.2). Webhooks compile to `apiContract#EndPoint` nodes
+   * that are byte-identical to regular endpoints; the only distinction is that
+   * the WebAPI root references them via `apiContract#webhooks` instead of
+   * `apiContract#endpoint`, so membership must be resolved from the model root.
+   * @param {any} operation The selected operation model.
+   * @returns {boolean} True when the operation is a top-level webhook operation.
+   */
+  _isWebhookOperation(operation) {
+    if (!operation) {
+      return false;
+    }
+    // Guard the mixin method at the package boundary: the shared
+    // amf-helper-mixin is versioned independently and `_computeWebhooks` only
+    // exists in webhook-aware builds. Mirrors the gRPC fork's guards in
+    // api-navigation (`typeof this._isGrpcApi === 'function'`).
+    if (typeof this._computeWebhooks !== 'function') {
+      return false;
+    }
+    let { amf } = this;
+    if (!amf) {
+      return false;
+    }
+    if (Array.isArray(amf)) {
+      [amf] = amf;
+    }
+    const webApi = this._computeApi(amf);
+    const webhooks = this._computeWebhooks(webApi);
+    if (!webhooks || !webhooks.length) {
+      return false;
+    }
+    const id = operation['@id'];
+    const opKey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.supportedOperation);
+    return webhooks.some((webhook) => {
+      const operations = this._ensureArray(webhook[opKey]);
+      return operations && operations.some((op) => op['@id'] === id);
+    });
   }
 
   get inlineMethods() {

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -12,6 +12,24 @@ window.customElements.define('helper-element', HelperElement);
 
 const helper = new HelperElement();
 
+/**
+ * amf-client-js 5.11.x emits models in flattened `@graph` form
+ * (`{"@graph":[...]}`), whereas 4.7 emitted a plain array (`[{...}]`). The
+ * `_compute*` helpers cannot navigate the raw `@graph` model — `_computeApi`
+ * returns `undefined`. The `amf` setter expands internally (via
+ * `AmfHelperMixin._expand`), so we expand here at load time and hand every
+ * consumer the navigable (expanded) model, restoring the 4.7 array shape.
+ * Re-feeding an already-expanded model to the element setter is idempotent
+ * (`isInExpandedForm` is a no-op without `@graph`), so the element keeps the
+ * same object graph and node identity (`node.type === lookupType(...)`) holds.
+ * @param {any} model Raw (possibly flattened `@graph`) API model.
+ * @return {any} Expanded model.
+ */
+const expand = (model) => {
+  helper.amf = model;
+  return helper.amf;
+};
+
 AmfLoader.load = async (fileName='demo-api', compact=false) => {
   const suffix = compact ? '-compact' : '';
   const file = `${fileName}${suffix}.json`;
@@ -20,7 +38,7 @@ AmfLoader.load = async (fileName='demo-api', compact=false) => {
   if (!response.ok) {
     throw new Error(`Unable to download API data model from ${url}`);
   }
-  return response.json();
+  return expand(await response.json());
 };
 
 AmfLoader.lookupEndpoint = (model, endpoint) => {
@@ -165,4 +183,34 @@ AmfLoader.lookupGrpcMethod = (model, serviceName, methodName) => {
     const name = helper._getValue(op, helper.ns.aml.vocabularies.core.name);
     return name === methodName;
   });
+};
+
+// OAS 3.1/3.2 top-level webhook helpers. A webhook compiles to an
+// `apiContract#EndPoint` node referenced by the WebAPI root via
+// `apiContract#webhooks` (not `apiContract#endpoint`).
+AmfLoader.lookupWebhook = (model, name) => {
+  helper.amf = model;
+  const webApi = helper._computeApi(model);
+  const webhooks = helper._computeWebhooks(webApi);
+  if (!webhooks) {
+    return undefined;
+  }
+  return webhooks.find((webhook) => {
+    const value = helper._getValue(webhook, helper.ns.aml.vocabularies.core.name)
+      || helper._getValue(webhook, helper.ns.aml.vocabularies.apiContract.path);
+    return value === name;
+  });
+};
+
+AmfLoader.lookupWebhookOperation = (model, name, method) => {
+  const webhook = AmfLoader.lookupWebhook(model, name);
+  if (!webhook) {
+    return undefined;
+  }
+  const opKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.supportedOperation);
+  const ops = helper._ensureArray(webhook[opKey]);
+  if (!ops) {
+    return undefined;
+  }
+  return ops.find((op) => helper._getValue(op, helper.ns.aml.vocabularies.apiContract.method) === method);
 };

--- a/test/webhooks.test.js
+++ b/test/webhooks.test.js
@@ -1,6 +1,6 @@
-/* eslint-disable no-shadow */
 import { fixture, assert, html, nextFrame } from '@open-wc/testing';
 import '../api-documentation.js';
+import { AmfLoader } from './amf-loader.js';
 
 /** @typedef {import('..').ApiDocumentationElement} ApiDocumentationElement */
 
@@ -12,126 +12,80 @@ import '../api-documentation.js';
  * A webhook compiles to an `apiContract#EndPoint` node identical to a regular
  * endpoint; the WebAPI root references it via `apiContract#webhooks`. There is
  * no operation-level flag, so `effectiveNoTryIt` resolves membership from the
- * model root through `_computeWebhooks`.
+ * model root through the mixin's `_computeWebhooks`.
  *
- * The model is built inline (expanded AMF, no `@context`) so this test does not
- * depend on the model generator. The shared amf-helper-mixin is versioned
- * independently; where the installed build predates `_computeWebhooks`, this
- * test supplies the method on the element instance to mirror the production
- * (webhook-aware) mixin — the webhook-endpoint resolution fallback itself is
- * covered by the amf-helper-mixin suite.
+ * These tests drive the REAL generated model (`demo/oas31-webhooks`, from
+ * `demo/oas31-webhooks/oas31-webhooks.yaml`) rather than hand-built AMF, so a
+ * regression in the generator's `apiContract#webhooks` predicate or in the
+ * webhook-aware amf-helper-mixin fails here instead of silently passing an
+ * inline fixture.
  */
 describe('ApiDocumentationElement webhooks (OAS 3.1/3.2)', () => {
-  const DOC = 'http://a.ml/vocabularies/document#Document';
-  const ENCODES = 'http://a.ml/vocabularies/document#encodes';
-  const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
-  const ENDPOINT = 'http://a.ml/vocabularies/apiContract#endpoint';
-  const WEBHOOKS = 'http://a.ml/vocabularies/apiContract#webhooks';
-  const ENDPOINT_T = 'http://a.ml/vocabularies/apiContract#EndPoint';
-  const OPERATION_T = 'http://a.ml/vocabularies/apiContract#Operation';
-  const SUPPORTED_OP = 'http://a.ml/vocabularies/apiContract#supportedOperation';
-  const PATH = 'http://a.ml/vocabularies/apiContract#path';
-  const METHOD = 'http://a.ml/vocabularies/apiContract#method';
-  const NAME = 'http://a.ml/vocabularies/core#name';
-
-  function buildModel() {
-    return {
-      '@type': [DOC],
-      [ENCODES]: [{
-        '@id': 'amf://id#1',
-        '@type': [WEBAPI],
-        [ENDPOINT]: [{
-          '@id': 'amf://id#10',
-          '@type': [ENDPOINT_T],
-          [PATH]: [{ '@value': '/pets' }],
-          [SUPPORTED_OP]: [{
-            '@id': 'amf://id#11',
-            '@type': [OPERATION_T],
-            [METHOD]: [{ '@value': 'get' }],
-          }],
-        }],
-        [WEBHOOKS]: [{
-          '@id': 'amf://id#20',
-          '@type': [ENDPOINT_T],
-          [PATH]: [{ '@value': 'newPet' }],
-          [NAME]: [{ '@value': 'newPet' }],
-          [SUPPORTED_OP]: [{
-            '@id': 'amf://id#21',
-            '@type': [OPERATION_T],
-            [METHOD]: [{ '@value': 'post' }],
-          }],
-        }],
-      }],
-    };
-  }
-
   /**
+   * @param {any} amf
    * @returns {Promise<ApiDocumentationElement>}
    */
   async function elementFixture(amf) {
     const el = /** @type ApiDocumentationElement */ (
       await fixture(html`<api-documentation .amf="${amf}"></api-documentation>`)
     );
-    // Ensure `_computeWebhooks` is available regardless of the installed mixin
-    // build, mirroring the production (webhook-aware) amf-helper-mixin.
-    if (typeof el._computeWebhooks !== 'function') {
-      el._computeWebhooks = function _computeWebhooks(webApi) {
-        if (!webApi) {
-          return [];
-        }
-        const key = this._getAmfKey('http://a.ml/vocabularies/apiContract#webhooks');
-        return this._ensureArray(webApi[key]);
-      };
-    }
     await nextFrame();
     return el;
   }
 
-  let model;
-  let webhookOperation;
-  let restOperation;
+  [true, false].forEach((compact) => {
+    describe(`${compact ? 'compact' : 'full'} model`, () => {
+      let model;
+      let webhookOperation;
+      let restOperation;
 
-  beforeEach(() => {
-    model = buildModel();
-    const webApi = model[ENCODES][0];
-    webhookOperation = webApi[WEBHOOKS][0][SUPPORTED_OP][0];
-    restOperation = webApi[ENDPOINT][0][SUPPORTED_OP][0];
-  });
+      beforeEach(async () => {
+        model = await AmfLoader.load('oas31-webhooks', compact);
+        webhookOperation = AmfLoader.lookupWebhookOperation(model, 'newPet', 'post');
+        restOperation = AmfLoader.lookupOperation(model, '/pets', 'get');
+      });
 
-  it('flags a top-level webhook operation via _isWebhookOperation', async () => {
-    const el = await elementFixture(model);
-    assert.isTrue(el._isWebhookOperation(webhookOperation));
-  });
+      it('resolves the top-level webhook operation from the generated model', () => {
+        assert.ok(webhookOperation, 'webhook operation is present in the model');
+        assert.ok(restOperation, 'REST operation is present in the model');
+      });
 
-  it('does not flag a regular endpoint operation as a webhook', async () => {
-    const el = await elementFixture(model);
-    assert.isFalse(el._isWebhookOperation(restOperation));
-  });
+      it('flags a top-level webhook operation via _isWebhookOperation', async () => {
+        const el = await elementFixture(model);
+        assert.isTrue(el._isWebhookOperation(webhookOperation));
+      });
 
-  it('suppresses Try-It for a selected webhook operation', async () => {
-    const el = await elementFixture(model);
-    el._docsModel = webhookOperation;
-    el._selectedType = 'method';
-    assert.isTrue(el.effectiveNoTryIt, 'effectiveNoTryIt is true for a webhook op');
-  });
+      it('does not flag a regular endpoint operation as a webhook', async () => {
+        const el = await elementFixture(model);
+        assert.isFalse(el._isWebhookOperation(restOperation));
+      });
 
-  it('keeps Try-It for a selected REST endpoint operation (per-operation suppression)', async () => {
-    const el = await elementFixture(model);
-    el._docsModel = restOperation;
-    el._selectedType = 'method';
-    assert.isFalse(el.effectiveNoTryIt, 'effectiveNoTryIt is false for a REST op');
-  });
+      it('suppresses Try-It for a selected webhook operation', async () => {
+        const el = await elementFixture(model);
+        el._docsModel = webhookOperation;
+        el._selectedType = 'method';
+        assert.isTrue(el.effectiveNoTryIt, 'effectiveNoTryIt is true for a webhook op');
+      });
 
-  it('still respects an explicit noTryIt for a REST op', async () => {
-    const el = await elementFixture(model);
-    el.noTryIt = true;
-    el._docsModel = restOperation;
-    el._selectedType = 'method';
-    assert.isTrue(el.effectiveNoTryIt, 'explicit noTryIt wins');
-  });
+      it('keeps Try-It for a selected REST endpoint operation (per-operation suppression)', async () => {
+        const el = await elementFixture(model);
+        el._docsModel = restOperation;
+        el._selectedType = 'method';
+        assert.isFalse(el.effectiveNoTryIt, 'effectiveNoTryIt is false for a REST op');
+      });
 
-  it('does not suppress Try-It when nothing is selected', async () => {
-    const el = await elementFixture(model);
-    assert.isFalse(el.effectiveNoTryIt);
+      it('still respects an explicit noTryIt for a REST op', async () => {
+        const el = await elementFixture(model);
+        el.noTryIt = true;
+        el._docsModel = restOperation;
+        el._selectedType = 'method';
+        assert.isTrue(el.effectiveNoTryIt, 'explicit noTryIt wins');
+      });
+
+      it('does not suppress Try-It when nothing is selected', async () => {
+        const el = await elementFixture(model);
+        assert.isFalse(el.effectiveNoTryIt);
+      });
+    });
   });
 });

--- a/test/webhooks.test.js
+++ b/test/webhooks.test.js
@@ -1,0 +1,137 @@
+/* eslint-disable no-shadow */
+import { fixture, assert, html, nextFrame } from '@open-wc/testing';
+import '../api-documentation.js';
+
+/** @typedef {import('..').ApiDocumentationElement} ApiDocumentationElement */
+
+/**
+ * Try-It is suppressed per-operation for OAS 3.1/3.2 top-level webhooks, exactly
+ * as it is for gRPC operations. Suppression is per-operation (not app-wide):
+ * a webhook API may still expose invokable REST endpoints, which keep Try-It.
+ *
+ * A webhook compiles to an `apiContract#EndPoint` node identical to a regular
+ * endpoint; the WebAPI root references it via `apiContract#webhooks`. There is
+ * no operation-level flag, so `effectiveNoTryIt` resolves membership from the
+ * model root through `_computeWebhooks`.
+ *
+ * The model is built inline (expanded AMF, no `@context`) so this test does not
+ * depend on the model generator. The shared amf-helper-mixin is versioned
+ * independently; where the installed build predates `_computeWebhooks`, this
+ * test supplies the method on the element instance to mirror the production
+ * (webhook-aware) mixin — the webhook-endpoint resolution fallback itself is
+ * covered by the amf-helper-mixin suite.
+ */
+describe('ApiDocumentationElement webhooks (OAS 3.1/3.2)', () => {
+  const DOC = 'http://a.ml/vocabularies/document#Document';
+  const ENCODES = 'http://a.ml/vocabularies/document#encodes';
+  const WEBAPI = 'http://a.ml/vocabularies/apiContract#WebAPI';
+  const ENDPOINT = 'http://a.ml/vocabularies/apiContract#endpoint';
+  const WEBHOOKS = 'http://a.ml/vocabularies/apiContract#webhooks';
+  const ENDPOINT_T = 'http://a.ml/vocabularies/apiContract#EndPoint';
+  const OPERATION_T = 'http://a.ml/vocabularies/apiContract#Operation';
+  const SUPPORTED_OP = 'http://a.ml/vocabularies/apiContract#supportedOperation';
+  const PATH = 'http://a.ml/vocabularies/apiContract#path';
+  const METHOD = 'http://a.ml/vocabularies/apiContract#method';
+  const NAME = 'http://a.ml/vocabularies/core#name';
+
+  function buildModel() {
+    return {
+      '@type': [DOC],
+      [ENCODES]: [{
+        '@id': 'amf://id#1',
+        '@type': [WEBAPI],
+        [ENDPOINT]: [{
+          '@id': 'amf://id#10',
+          '@type': [ENDPOINT_T],
+          [PATH]: [{ '@value': '/pets' }],
+          [SUPPORTED_OP]: [{
+            '@id': 'amf://id#11',
+            '@type': [OPERATION_T],
+            [METHOD]: [{ '@value': 'get' }],
+          }],
+        }],
+        [WEBHOOKS]: [{
+          '@id': 'amf://id#20',
+          '@type': [ENDPOINT_T],
+          [PATH]: [{ '@value': 'newPet' }],
+          [NAME]: [{ '@value': 'newPet' }],
+          [SUPPORTED_OP]: [{
+            '@id': 'amf://id#21',
+            '@type': [OPERATION_T],
+            [METHOD]: [{ '@value': 'post' }],
+          }],
+        }],
+      }],
+    };
+  }
+
+  /**
+   * @returns {Promise<ApiDocumentationElement>}
+   */
+  async function elementFixture(amf) {
+    const el = /** @type ApiDocumentationElement */ (
+      await fixture(html`<api-documentation .amf="${amf}"></api-documentation>`)
+    );
+    // Ensure `_computeWebhooks` is available regardless of the installed mixin
+    // build, mirroring the production (webhook-aware) amf-helper-mixin.
+    if (typeof el._computeWebhooks !== 'function') {
+      el._computeWebhooks = function _computeWebhooks(webApi) {
+        if (!webApi) {
+          return [];
+        }
+        const key = this._getAmfKey('http://a.ml/vocabularies/apiContract#webhooks');
+        return this._ensureArray(webApi[key]);
+      };
+    }
+    await nextFrame();
+    return el;
+  }
+
+  let model;
+  let webhookOperation;
+  let restOperation;
+
+  beforeEach(() => {
+    model = buildModel();
+    const webApi = model[ENCODES][0];
+    webhookOperation = webApi[WEBHOOKS][0][SUPPORTED_OP][0];
+    restOperation = webApi[ENDPOINT][0][SUPPORTED_OP][0];
+  });
+
+  it('flags a top-level webhook operation via _isWebhookOperation', async () => {
+    const el = await elementFixture(model);
+    assert.isTrue(el._isWebhookOperation(webhookOperation));
+  });
+
+  it('does not flag a regular endpoint operation as a webhook', async () => {
+    const el = await elementFixture(model);
+    assert.isFalse(el._isWebhookOperation(restOperation));
+  });
+
+  it('suppresses Try-It for a selected webhook operation', async () => {
+    const el = await elementFixture(model);
+    el._docsModel = webhookOperation;
+    el._selectedType = 'method';
+    assert.isTrue(el.effectiveNoTryIt, 'effectiveNoTryIt is true for a webhook op');
+  });
+
+  it('keeps Try-It for a selected REST endpoint operation (per-operation suppression)', async () => {
+    const el = await elementFixture(model);
+    el._docsModel = restOperation;
+    el._selectedType = 'method';
+    assert.isFalse(el.effectiveNoTryIt, 'effectiveNoTryIt is false for a REST op');
+  });
+
+  it('still respects an explicit noTryIt for a REST op', async () => {
+    const el = await elementFixture(model);
+    el.noTryIt = true;
+    el._docsModel = restOperation;
+    el._selectedType = 'method';
+    assert.isTrue(el.effectiveNoTryIt, 'explicit noTryIt wins');
+  });
+
+  it('does not suppress Try-It when nothing is selected', async () => {
+    const el = await elementFixture(model);
+    assert.isFalse(el.effectiveNoTryIt);
+  });
+});


### PR DESCRIPTION
## @W-23748894

### What

Renders OAS 3.1/3.2 top-level webhooks as first-class documentation.

Part of the webhooks feature for TD-0333486. Depends on `@api-components/amf-helper-mixin` **>= 4.5.36** (PR `W-23748894-webhooks` on that repo), which resolves top-level `apiContract#webhooks` via an additive fallback.

Per-repo behavior:
- **api-navigation** — dedicated "Webhooks" nav section.
- **api-method-documentation** — shows the webhook event name instead of a URL.
- **api-documentation** — suppresses the per-operation Try-It for webhooks (webhooks are event-driven; there is nothing to invoke).

### Why

Webhooks are top-level in OAS 3.1/3.2 (not under `paths`). AC4: webhooks must render as their own first-class section with Try-It suppressed.

### Dependency / publish gate

**Ship the mixin (4.5.36) first**, then raise the peer floor to `^4.5.36` here. Below 4.5.36 the resolver fallback does not exist and the feature **silently no-ops** with no error/log/metric.

### Tests

Green in chromium + firefox. Inline AMF expanded-model fixtures.

### Known QA notes (P2, non-blocking, tracked for the PR discussion)

- AC-03 is proven in two halves (mixin suite proves resolution on 4.5.36 source; this suite proves suppression on the installed mixin) — no single end-to-end select→resolve→render→no-Try-It test, and no `.action` DOM-absence assertion.
- No test consumes the real generated model; a future generator change to the `apiContract#webhooks` predicate would pass GREEN and break prod. A smoke test against a real compact model (at least in nav) is recommended.

### Scope

Draft for review.
